### PR TITLE
breaking: platform-first user mgmt, secret-edit, bulk-user flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,7 @@ celerybeat.pid
 .env
 .env.live
 .env.*.local
+.creds
 .venv
 env/
 venv/

--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,8 @@ celerybeat.pid
 
 # Environments
 .env
+.env.live
+.env.*.local
 .venv
 env/
 venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,12 +59,13 @@ the Platform identity API by default.
   and `GetUser` was replaced by `GetUserAttributes` (POST `{"ID": …}`).
   This release fixes those paths.
 - Role mutation endpoints (`SaasManage/StoreRole`, `Roles/UpdateRole`,
-  etc.) are **not exposed** via the `xpmheadless` OAuth scope on modern
-  Platform tenants. `platform_role_management` and
-  `platform_user_role_management` therefore support read actions
-  (`list`, `get`) but return a structured "not supported on this scope"
-  error for write actions, directing the caller to use the SS-side
-  `role_management` tool or the Platform admin UI.
+  `SaasManage/RemoveRole`) are **discovery-driven**: the tools attempt
+  the documented endpoint and only fall back to a structured guidance
+  error on HTTP 404 (typical on modern Platform tenants using the
+  `xpmheadless` scope, which exposes user CRUD but not role CRUD).
+  Tenants that DO expose those endpoints get the real result. The
+  guidance error directs callers to the SS-side `role_management` /
+  `user_role_management` tools or the Platform admin UI.
 
 The current release introduces a comprehensive tool set for integrating Delinea Secret Server with the Model Context Protocol.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Release Notes
 
+## v1.0.0 — Platform-first user management (breaking)
+
+In Delinea cloud and Platform-integrated tenants the authoritative user
+store is the Delinea Platform identity directory; Secret Server's own
+`/v1/users/*` endpoints only manage local-mirror records there. v1.0.0
+makes the canonical `user_management` and `search_users` tools talk to
+the Platform identity API by default.
+
+### Breaking
+
+- `user_management` now talks to the Delinea Platform identity API
+  (`/identity/CDirectoryService/*`, `/identity/UserMgmt/*`). The previous
+  Secret-Server-local implementation has moved to
+  `secretserver_local_user_management` (in
+  `delinea_mcp.secretserver_users`).
+- `search_users` now searches the Platform user directory. The previous
+  `/v1/users` search has moved to `search_secretserver_local_users`.
+- Clients that pinned `enabled_tools` to `user_management` /
+  `search_users` will now hit Platform endpoints. SS-only deployments
+  must either:
+  1. configure Platform (`PLATFORM_HOSTNAME`,
+     `PLATFORM_SERVICE_ACCOUNT`, `PLATFORM_SERVICE_PASSWORD`,
+     `PLATFORM_TENANT_ID`), or
+  2. switch the client to the new `secretserver_local_*` tool names.
+
+### Added
+
+- **`update_secret_fields`** — read-template → mutate-non-password-fields
+  → verify flow. Refuses fields whose template marks `isPassword=True`
+  unless `allow_password_fields=True`; routes audit comments through
+  `autoCheckout`/`autoCheckIn`/`autoComment` query params.
+- **`bulk_user_response`** — opinionated combinator over
+  `/v1/bulk-user-operations/*`. Scenarios: `compromise`, `offboard`,
+  `unlock`, `reenable`, `force_logout`. Requires `confirm=True` _and_ a
+  non-empty `comment`; `confirm=False` returns a preview that makes no
+  API calls.
+- **`platform_role_management`** — Platform identity role CRUD using
+  `SaasManage/StoreRole`, `Roles/UpdateRole`, `Redrock/Query`, and
+  `SaasManage/RemoveRole`.
+- **`platform_user_role_management`** — add/remove/list users on a
+  Platform role via `Roles/UpdateRole` `Users.Add`/`Users.Delete`.
+- **`platform_user_management`** retained as a deprecated alias for
+  `user_management`; old clients keep working.
+
+### Notes
+
+- Live-verified against a Secret-Server cloud tenant for all SS-side
+  flows. Platform-side tools (`user_management`, `search_users`,
+  `platform_role_management`, `platform_user_role_management`) are
+  unit-tested only — Platform creds were not available during this
+  release; please verify against your tenant before relying on them in
+  production.
+
 The current release introduces a comprehensive tool set for integrating Delinea Secret Server with the Model Context Protocol.
 
 ## Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,12 +46,25 @@ the Platform identity API by default.
 
 ### Notes
 
-- Live-verified against a Secret-Server cloud tenant for all SS-side
-  flows. Platform-side tools (`user_management`, `search_users`,
-  `platform_role_management`, `platform_user_role_management`) are
-  unit-tested only — Platform creds were not available during this
-  release; please verify against your tenant before relying on them in
-  production.
+- Live-verified against:
+  - a Secret-Server cloud tenant for all SS-side flows
+    (`update_secret_fields`, `bulk_user_response` preview,
+    `secretserver_local_*`, search/fetch).
+  - a Delinea Platform tenant (`dartlabs.secureplatform.io`) for the
+    Platform-side flows (`user_management` full CRUD lifecycle,
+    `search_users`, `platform_role_management` read, `platform_user_role_management`
+    read). 32 live integration tests pass.
+- Platform endpoint discovery: on modern Delinea Platform tenants the
+  identity-API namespace is `/identity/api/...` (not `/identity/...`),
+  and `GetUser` was replaced by `GetUserAttributes` (POST `{"ID": …}`).
+  This release fixes those paths.
+- Role mutation endpoints (`SaasManage/StoreRole`, `Roles/UpdateRole`,
+  etc.) are **not exposed** via the `xpmheadless` OAuth scope on modern
+  Platform tenants. `platform_role_management` and
+  `platform_user_role_management` therefore support read actions
+  (`list`, `get`) but return a structured "not supported on this scope"
+  error for write actions, directing the caller to use the SS-side
+  `role_management` tool or the Platform admin UI.
 
 The current release introduces a comprehensive tool set for integrating Delinea Secret Server with the Model Context Protocol.
 

--- a/delinea_mcp/secretserver_users.py
+++ b/delinea_mcp/secretserver_users.py
@@ -1,0 +1,193 @@
+"""Legacy Secret Server local user/search tooling.
+
+Modern Delinea cloud deployments authenticate users through the Delinea
+Platform identity provider. The tools in this module talk directly to
+Secret Server's own ``/v1/users`` endpoints, which only manage the
+*local* user records inside Secret Server.
+
+For Platform-integrated tenants, use :mod:`delinea_mcp.user_platform_tools`
+(registered as ``user_management`` and ``search_users``) instead.
+
+These functions are preserved under the ``secretserver_local_*`` names for
+SS-only on-prem deployments and as a fallback during migration.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .session import SessionManager
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_json_data(data: dict | str | None) -> dict | None:
+    import json as _json
+
+    if isinstance(data, str):
+        try:
+            return _json.loads(data)
+        except Exception as exc:
+            logger.exception("Failed to parse JSON string")
+            raise ValueError("Invalid JSON data") from exc
+    return data
+
+
+def search_secretserver_local_users(query: str) -> dict:
+    """Search local Secret Server users (legacy SS-only deployments).
+
+    Calls ``GET /v1/users?filter.searchText=<query>``.  In Platform-integrated
+    tenants, prefer :func:`delinea_mcp.user_platform_tools.search_users`,
+    which queries Platform's identity directory and is the authoritative
+    user store.
+
+    Parameters
+    ----------
+    query:
+        Text to search for in usernames or display names.
+
+    Returns
+    -------
+    dict
+        Raw search results as returned by the API.
+    """
+    logger.debug("search_secretserver_local_users(%s)", query)
+    session = SessionManager.get()
+    try:
+        return session.request(
+            "GET", "/v1/users", params={"filter.searchText": query}
+        ).json()
+    except Exception as exc:  # pragma: no cover - network failures
+        logger.exception("Failed to search local SS users %s", query)
+        return {"error": f"Failed to search users '{query}': {exc}"}
+
+
+def secretserver_local_user_management(
+    action: str,
+    user_id: int | None = None,
+    data: dict | None = None,
+    *,
+    skip: int = 0,
+    take: int = 20,
+    is_exporting: bool = False,
+) -> dict:
+    """Manage local Secret Server users (legacy SS-only deployments).
+
+    For Platform-integrated tenants the authoritative user store is the
+    Platform identity directory; use the canonical ``user_management``
+    tool (provided by :mod:`delinea_mcp.user_platform_tools`) instead.
+
+    This function operates on Secret Server's own ``/v1/users`` records,
+    which in Platform tenants are typically read-only mirrors of Platform
+    users.  Mutations performed here will not propagate to the Platform.
+
+    Parameters
+    ----------
+    action:
+        Operation to perform: ``"get"``, ``"create"``, ``"update"``,
+        ``"delete"``, ``"list_sessions"``, ``"reset_2fa"``,
+        ``"reset_password"`` or ``"lock_out"``.
+    user_id:
+        Target user identifier. Required for all actions except ``"create"``
+        and ``"list_sessions"``.
+    data:
+        JSON body for ``"create"``, ``"update"`` and ``"reset_password"``.
+    skip, take:
+        Pagination controls for ``"list_sessions"``.
+    is_exporting:
+        Include the ``isExporting`` flag when listing sessions.
+
+    Returns
+    -------
+    dict
+        Dictionary with ``result`` from the write action and ``verification``
+        from the subsequent ``GET``, or the raw API payload for read actions.
+    """
+
+    logger.debug(
+        "secretserver_local_user_management(action=%s, user_id=%s, data=%s)",
+        action,
+        user_id,
+        data,
+    )
+    session = SessionManager.get()
+
+    data = _parse_json_data(data)
+
+    try:
+        if action == "get":
+            if user_id is None:
+                raise ValueError("user_id required for get")
+            return session.request("GET", f"/v1/users/{user_id}").json()
+        if action == "create":
+            result = session.request("POST", "/v1/users", json=data or {}).json()
+            user_id = result.get("id") or result.get("userId")
+            verify: dict[str, Any] = {}
+            if user_id is not None:
+                try:
+                    verify = session.request("GET", f"/v1/users/{user_id}").json()
+                except Exception as exc:  # pragma: no cover - network failures
+                    logger.exception("User verification failed after create")
+                    verify = {"error": str(exc)}
+            return {"result": result, "verification": verify}
+        if action == "update":
+            if user_id is None or data is None:
+                raise ValueError("user_id and data required for update")
+            result = session.request("PUT", f"/v1/users/{user_id}", json=data).json()
+            verify = {}
+            try:
+                verify = session.request("GET", f"/v1/users/{user_id}").json()
+            except Exception as exc:  # pragma: no cover - network failures
+                logger.exception("User verification failed after update")
+                verify = {"error": str(exc)}
+            return {"result": result, "verification": verify}
+        if action == "delete":
+            if user_id is None:
+                raise ValueError("user_id required for delete")
+            result = session.request("DELETE", f"/v1/users/{user_id}").json()
+            verify = {}
+            try:
+                verify = session.request("GET", f"/v1/users/{user_id}").json()
+            except Exception as exc:  # pragma: no cover - network failures
+                verify = {"error": str(exc)}
+            return {"result": result, "verification": verify}
+        if action == "list_sessions":
+            params: dict[str, Any] = {"skip": skip, "take": take}
+            if is_exporting:
+                params["isExporting"] = True
+            return session.request("GET", "/v1/users/sessions", params=params).json()
+        if action == "reset_2fa":
+            if user_id is None:
+                raise ValueError("user_id required for reset_2fa")
+            return session.request(
+                "POST", f"/v1/users/{user_id}/reset-two-factor", json=data or {}
+            ).json()
+        if action == "reset_password":
+            if user_id is None or data is None:
+                raise ValueError("user_id and data required for reset_password")
+            return session.request(
+                "POST", f"/v1/users/{user_id}/password-reset", json=data
+            ).json()
+        if action == "lock_out":
+            if user_id is None:
+                raise ValueError("user_id required for lock_out")
+            return session.request(
+                "POST", f"/v1/users/{user_id}/lock-out", json=data or {}
+            ).json()
+        raise ValueError(f"Unknown action: {action}")
+    except Exception as exc:  # pragma: no cover - network failures
+        logger.exception("Local SS user management action failed")
+        return {"error": str(exc)}
+
+
+TOOLS = [
+    ("search_secretserver_local_users", search_secretserver_local_users),
+    ("secretserver_local_user_management", secretserver_local_user_management),
+]
+
+
+def register(mcp: Any) -> None:
+    """Register the legacy SS-local user tools on a FastMCP server."""
+    for _name, func in TOOLS:
+        mcp.tool()(func)

--- a/delinea_mcp/tools.py
+++ b/delinea_mcp/tools.py
@@ -816,30 +816,6 @@ def get_folder(id: int) -> dict:
         return {"error": f"Failed to retrieve folder {id}: {exc}"}
 
 
-def search_users(query: str) -> dict:
-    """Search active users by text.
-
-    Parameters
-    ----------
-    query:
-        Text to search for in usernames or display names.
-
-    Returns
-    -------
-    dict
-        Raw search results as returned by the API.
-    """
-    logger.debug("search_users(%s)", query)
-    session = SessionManager.get()
-    try:
-        return session.request(
-            "GET", "/v1/users", params={"filter.searchText": query}
-        ).json()
-    except Exception as exc:  # pragma: no cover - network failures
-        logger.exception("Failed to search users %s", query)
-        return {"error": f"Failed to search users '{query}': {exc}"}
-
-
 def search_secrets(query: str, lookup: bool = False) -> dict:
     """Search or look up secrets.
 
@@ -1155,133 +1131,6 @@ def mark_inbox_messages_read(
     except Exception as exc:
         logger.exception("Failed to mark inbox messages read/unread")
         return {"error": f"Failed to mark inbox messages read/unread: {exc}"}
-
-
-def user_management(
-    action: str,
-    user_id: int | None = None,
-    data: dict | None = None,
-    *,
-    skip: int = 0,
-    take: int = 20,
-    is_exporting: bool = False,
-) -> dict:
-    """Manage users via a single helper.
-
-    Parameters
-    ----------
-    action:
-        Operation to perform: ``"get"``, ``"create"``, ``"update"``, ``"delete"``,
-        ``"list_sessions"``, ``"reset_2fa"``, ``"reset_password"`` or ``"lock_out"``.
-    user_id:
-        Target user identifier. Required for all actions except ``"create"`` and
-        ``"list_sessions"``.
-    data:
-        JSON body for ``"create"``, ``"update"`` and ``"reset_password"``.
-    skip, take:
-        Pagination controls for ``"list_sessions"``.
-    is_exporting:
-        Include the ``isExporting`` flag when listing sessions.
-
-    When ``action`` is ``"create"``, ``data`` must include the required keys
-    ``userName``, ``password`` and ``displayName``. Optional keys such as
-    ``adGuid``, ``domainId``, ``duoTwoFactor``, ``emailAddress``, ``enabled``,
-    ``fido2TwoFactor``, ``isApplicationAccount``, ``oathTwoFactor``,
-    ``radiusTwoFactor``, ``radiusUserName``, ``twoFactor`` and
-    ``unixAuthenticationMethod`` may also be supplied. Password must adhere
-    to password security rules otherwise a 400 failure may occur.
-    When ``action`` is ``"update"``, you need to do a get first, update the
-    relevant fields and post everything back.
-
-    For ``"create"``, ``"update"`` and ``"delete"`` actions the function
-    performs an additional ``GET`` request after the operation to verify the
-    result. The returned dictionary contains two keys: ``result`` with the
-    original API response and ``verification`` with the data retrieved by the
-    follow-up ``GET``.
-
-    Returns
-    -------
-    dict
-        Dictionary with ``result`` from the write action and ``verification``
-        from the subsequent ``GET``.
-
-    Examples
-    --------
-    >>> user_management("get", user_id=10)
-    >>> user_management("create", data={"username": "alice"})
-    """
-
-    logger.debug(
-        "user_management(action=%s, user_id=%s, data=%s)", action, user_id, data
-    )
-    session = SessionManager.get()
-
-    data = _parse_json_data(data)
-
-    try:
-        if action == "get":
-            if user_id is None:
-                raise ValueError("user_id required for get")
-            return session.request("GET", f"/v1/users/{user_id}").json()
-        if action == "create":
-            result = session.request("POST", "/v1/users", json=data or {}).json()
-            user_id = result.get("id") or result.get("userId")
-            verify = {}
-            if user_id is not None:
-                try:
-                    verify = session.request("GET", f"/v1/users/{user_id}").json()
-                except Exception as exc:  # pragma: no cover - network failures
-                    logger.exception("User verification failed after create")
-                    verify = {"error": str(exc)}
-            return {"result": result, "verification": verify}
-        if action == "update":
-            if user_id is None or data is None:
-                raise ValueError("user_id and data required for update")
-            result = session.request("PUT", f"/v1/users/{user_id}", json=data).json()
-            verify = {}
-            try:
-                verify = session.request("GET", f"/v1/users/{user_id}").json()
-            except Exception as exc:  # pragma: no cover - network failures
-                logger.exception("User verification failed after update")
-                verify = {"error": str(exc)}
-            return {"result": result, "verification": verify}
-        if action == "delete":
-            if user_id is None:
-                raise ValueError("user_id required for delete")
-            result = session.request("DELETE", f"/v1/users/{user_id}").json()
-            verify = {}
-            try:
-                verify = session.request("GET", f"/v1/users/{user_id}").json()
-            except Exception as exc:  # pragma: no cover - network failures
-                verify = {"error": str(exc)}
-            return {"result": result, "verification": verify}
-        if action == "list_sessions":
-            params = {"skip": skip, "take": take}
-            if is_exporting:
-                params["isExporting"] = True
-            return session.request("GET", "/v1/users/sessions", params=params).json()
-        if action == "reset_2fa":
-            if user_id is None:
-                raise ValueError("user_id required for reset_2fa")
-            return session.request(
-                "POST", f"/v1/users/{user_id}/reset-two-factor", json=data or {}
-            ).json()
-        if action == "reset_password":
-            if user_id is None or data is None:
-                raise ValueError("user_id and data required for reset_password")
-            return session.request(
-                "POST", f"/v1/users/{user_id}/password-reset", json=data
-            ).json()
-        if action == "lock_out":
-            if user_id is None:
-                raise ValueError("user_id required for lock_out")
-            return session.request(
-                "POST", f"/v1/users/{user_id}/lock-out", json=data or {}
-            ).json()
-        raise ValueError(f"Unknown action: {action}")
-    except Exception as exc:  # pragma: no cover - network failures
-        logger.exception("User management action failed")
-        return {"error": str(exc)}
 
 
 def role_management(
@@ -1714,9 +1563,11 @@ def search(query: str) -> Dict[str, List[Dict[str, Any]]]:
         defined by the MCP specification.
     """
     logger.debug("search(%s)", query)
+    from . import secretserver_users
+
     mapping = {
         "secret": search_secrets,
-        "user": search_users,
+        "user": secretserver_users.search_secretserver_local_users,
         "folder": search_folders,
         "group": lambda q: group_management("list", params={"filter.searchText": q}),
         "role": lambda q: role_management("list", params={"filter.searchText": q}),
@@ -1801,9 +1652,13 @@ def fetch(id: str) -> Dict[str, Any]:
     if kind not in _FETCH_ALLOWED:
         raise ValueError(f"fetch for {kind} not enabled")
 
+    from . import secretserver_users
+
     mapping = {
         "secret": lambda i: get_secret(int(i)),
-        "user": lambda i: user_management("get", user_id=int(i)),
+        "user": lambda i: secretserver_users.secretserver_local_user_management(
+            "get", user_id=int(i)
+        ),
         "folder": lambda i: get_folder(int(i)),
         "group": lambda i: group_management("get", group_id=int(i)),
         "role": lambda i: role_management("get", role_id=int(i)),
@@ -1841,6 +1696,349 @@ def fetch(id: str) -> Dict[str, Any]:
     }
 
 
+def update_secret_fields(
+    secret_id: int,
+    field_updates: dict[str, str] | str,
+    comment: str | None = None,
+    *,
+    allow_password_fields: bool = False,
+) -> dict:
+    """Edit non-sensitive fields on an existing secret.
+
+    Composes the read-mutate-verify flow:
+
+    1. ``GET /v1/secrets/{id}/summary`` to check approval / comment
+       requirements via :func:`_check_secret_approval`.
+    2. ``GET /v1/secrets/{id}`` (template lookup) to identify which slugs
+       are password fields.
+    3. ``PUT /v1/secrets/{id}/fields/{slug}`` per entry in *field_updates*.
+    4. ``GET /v1/secrets/{id}/summary`` for verification.
+
+    By default, slugs whose template field has ``isPassword=True`` are
+    refused — the model should not see plaintext password values.  Use
+    :func:`set_secret_field_environment_variable` (which emits a shell
+    script that reads the value locally and PUTs it without the value
+    ever passing through the model) for password-class fields, or set
+    ``allow_password_fields=True`` to override (not recommended).
+
+    Parameters
+    ----------
+    secret_id:
+        Identifier of the secret to update.
+    field_updates:
+        Mapping of ``field_slug -> new_value`` (or a JSON string).  Use
+        slugs (e.g. ``"notes"``, ``"url"``, ``"hostname"``) discoverable
+        via :func:`check_secret_template`.
+    comment:
+        Audit comment recorded against each field update.  Required when
+        the secret has ``requiresComment`` or ``requiresApproval`` set.
+        Must explain **why** the change is being made and reference any
+        related ticket, incident, or change request.
+    allow_password_fields:
+        Set to ``True`` to permit updating password-class fields.  Doing
+        so means the new value passes through the model — prefer
+        :func:`set_secret_field_environment_variable` for those fields.
+
+    Returns
+    -------
+    dict
+        ``{"result": {...}, "verification": {...}}`` where ``result`` lists
+        per-field outcomes and ``verification`` is the post-update summary.
+    """
+
+    logger.debug(
+        "update_secret_fields(secret_id=%s, field_count=%s)",
+        secret_id,
+        len(field_updates) if hasattr(field_updates, "__len__") else "?",
+    )
+    session = SessionManager.get()
+
+    parsed = (
+        _parse_json_data(field_updates)
+        if isinstance(field_updates, str)
+        else field_updates
+    )
+    if not isinstance(parsed, dict) or not parsed:
+        return {"error": "field_updates must be a non-empty mapping of slug -> value"}
+
+    # Pre-check approval requirements
+    check = _check_secret_approval(session, secret_id, comment)
+    if check is not None:
+        return check
+
+    # Identify password-class fields on this secret's template
+    password_slugs: set[str] = set()
+    if not allow_password_fields:
+        try:
+            secret = session.request("GET", f"/v2/secrets/{secret_id}").json()
+            template_id = secret.get("secretTemplateId")
+            if template_id is not None:
+                tmpl = session.request(
+                    "GET", f"/v1/secret-templates/{template_id}"
+                ).json()
+                for f in tmpl.get("fields", []) or []:
+                    if f.get("isPassword"):
+                        slug = (
+                            f.get("fieldSlugName") or f.get("slugName") or f.get("name")
+                        )
+                        if slug:
+                            password_slugs.add(str(slug).lower())
+        except Exception as exc:  # pragma: no cover - network failures
+            logger.exception("Failed to inspect template for password fields")
+            return {
+                "error": (
+                    f"Failed to verify password-field safety for secret {secret_id}: "
+                    f"{exc}. Pass allow_password_fields=True to override."
+                )
+            }
+
+    refused = [slug for slug in parsed if str(slug).lower() in password_slugs]
+    if refused:
+        return {
+            "error": (
+                f"Refusing to update password-class field(s) {refused} via this tool. "
+                "Use set_secret_field_environment_variable so the value never enters "
+                "the model context, or pass allow_password_fields=True to override."
+            )
+        }
+
+    common_params = None
+    if comment:
+        common_params = {
+            "autoCheckout": "true",
+            "autoCheckIn": "true",
+            "autoComment": comment,
+        }
+
+    per_field: list[dict] = []
+    for slug, value in parsed.items():
+        try:
+            kwargs: dict[str, Any] = {"json": {"value": value}}
+            if common_params:
+                kwargs["params"] = common_params
+            session.request("PUT", f"/v1/secrets/{secret_id}/fields/{slug}", **kwargs)
+            per_field.append({"slug": slug, "updated": True})
+        except Exception as exc:  # pragma: no cover - network failures
+            logger.exception("Failed to update field %s on secret %s", slug, secret_id)
+            per_field.append({"slug": slug, "updated": False, "error": str(exc)})
+
+    verify: dict = {}
+    try:
+        verify = session.request("GET", f"/v1/secrets/{secret_id}/summary").json()
+    except Exception as exc:  # pragma: no cover - network failures
+        logger.exception("Secret verification failed after field updates")
+        verify = {"error": str(exc)}
+
+    return {
+        "result": {
+            "secret_id": secret_id,
+            "fields": per_field,
+            "all_updated": all(r.get("updated") for r in per_field),
+        },
+        "verification": verify,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# bulk_user_response                                                          #
+# --------------------------------------------------------------------------- #
+
+
+# Each scenario is an ordered list of (label, path, body-builder).  The body
+# builder receives the user_ids list and returns the JSON body for the POST.
+def _bulk_user_body(user_ids: list[int]) -> dict:
+    return {"data": {"userIds": user_ids}}
+
+
+_BULK_USER_SCENARIOS: dict[str, list[tuple[str, str]]] = {
+    # Compromise response: kill sessions, lock, disable account, strip 2FA so
+    # the attacker can't re-enrol.  Order matters: force-logout first to evict
+    # active sessions before the account is disabled.
+    "compromise": [
+        ("force_logout", "/v1/bulk-user-operations/force-logout"),
+        ("lock", "/v1/bulk-user-operations/lock"),
+        ("disable", "/v1/bulk-user-operations/disable"),
+        ("reset_fido2", "/v1/bulk-user-operations/reset-fido2-two-factor"),
+        ("reset_totp", "/v1/bulk-user-operations/reset-totp-auth"),
+    ],
+    # Offboarding: more graceful.  Disable the account and force logout, but
+    # keep 2FA factors registered so audit trails remain intact.
+    "offboard": [
+        ("force_logout", "/v1/bulk-user-operations/force-logout"),
+        ("disable", "/v1/bulk-user-operations/disable"),
+    ],
+    # Restore access after a temporary lockout / IR action.
+    "unlock": [
+        ("unlock", "/v1/bulk-user-operations/unlock"),
+        ("enable", "/v1/bulk-user-operations/enable"),
+    ],
+    # Re-enable a disabled-but-not-locked account.
+    "reenable": [
+        ("enable", "/v1/bulk-user-operations/enable"),
+    ],
+    # Just kick active sessions.
+    "force_logout": [
+        ("force_logout", "/v1/bulk-user-operations/force-logout"),
+    ],
+}
+
+
+def bulk_user_response(
+    user_ids: list[int] | str,
+    scenario: str,
+    comment: str,
+    *,
+    confirm: bool = False,
+) -> dict:
+    """Apply an opinionated sequence of bulk user operations.
+
+    .. warning::
+        This tool can lock out, disable, or strip 2FA from many users in a
+        single call.  It is intended for incident response (e.g. compromised
+        accounts), bulk offboarding, or break-glass restoration.  **Always
+        verify the user_ids list with the caller before invoking** and
+        require an explicit ``confirm=True`` plus a meaningful audit
+        ``comment`` referencing the ticket/incident.
+
+    Composes calls to ``POST /v1/bulk-user-operations/*`` endpoints in the
+    sequence prescribed by *scenario*.
+
+    Scenarios
+    ---------
+    ``"compromise"``
+        Force-logout → lock → disable → reset FIDO2 → reset TOTP.  Use when
+        an account is suspected of compromise and you want the strongest
+        possible response.
+    ``"offboard"``
+        Force-logout → disable.  Less aggressive — keeps 2FA registrations
+        so audit trails remain meaningful.
+    ``"unlock"``
+        Unlock → enable.  Reverses a prior lockout/disable.
+    ``"reenable"``
+        Enable only.  Use after ``"compromise"`` was applied in error.
+    ``"force_logout"``
+        Just terminate active sessions.
+
+    Parameters
+    ----------
+    user_ids:
+        List of user identifiers (or JSON string of the same).
+    scenario:
+        One of the scenario names listed above.
+    comment:
+        Required audit comment.  Must reference the ticket/incident and
+        explain *why* this action is being taken.  An empty comment is
+        rejected.
+    confirm:
+        Must be set to ``True`` to actually run any destructive scenario.
+        ``"unlock"``, ``"reenable"`` and ``"force_logout"`` also require
+        confirmation, but planning calls (``confirm=False``) return a
+        preview of what the tool would do.
+
+    Returns
+    -------
+    dict
+        On preview (``confirm=False``): ``{"preview": {...}}`` with the
+        list of steps and target user_ids, no API calls made.
+        On execute: ``{"result": {...}, "verification": {...}}`` where
+        ``result`` lists per-step API responses and ``verification`` is
+        a fresh user listing for the affected ids.
+    """
+
+    logger.debug(
+        "bulk_user_response(scenario=%s, n_users=%s, confirm=%s)",
+        scenario,
+        len(user_ids) if hasattr(user_ids, "__len__") else "?",
+        confirm,
+    )
+
+    if scenario not in _BULK_USER_SCENARIOS:
+        return {
+            "error": (
+                f"Unknown scenario {scenario!r}. "
+                f"Valid: {sorted(_BULK_USER_SCENARIOS)}"
+            )
+        }
+
+    if isinstance(user_ids, str):
+        try:
+            user_ids = json.loads(user_ids)
+        except Exception:
+            return {"error": "user_ids must be a list or a JSON-encoded list"}
+    if not isinstance(user_ids, list) or not user_ids:
+        return {"error": "user_ids must be a non-empty list"}
+    try:
+        ids = [int(i) for i in user_ids]
+    except Exception:
+        return {"error": "user_ids must contain integers"}
+
+    if not isinstance(comment, str) or not comment.strip():
+        return {
+            "error": (
+                "comment is required and must explain why this bulk action "
+                "is being taken (include ticket/incident reference)"
+            )
+        }
+
+    steps = _BULK_USER_SCENARIOS[scenario]
+
+    if not confirm:
+        return {
+            "preview": {
+                "scenario": scenario,
+                "user_ids": ids,
+                "user_count": len(ids),
+                "steps": [label for label, _ in steps],
+                "comment": comment,
+                "note": (
+                    "No API calls were made. Pass confirm=True to execute. "
+                    "Verify the user_ids list with a human before confirming."
+                ),
+            }
+        }
+
+    session = SessionManager.get()
+    body = _bulk_user_body(ids)
+
+    per_step: list[dict] = []
+    for label, path in steps:
+        try:
+            resp = session.request("POST", path, json=body)
+            payload = resp.json() if resp.content else {"success": True}
+            per_step.append({"step": label, "ok": True, "response": payload})
+        except Exception as exc:  # pragma: no cover - network failures
+            logger.exception("bulk_user_response step %s failed", label)
+            per_step.append({"step": label, "ok": False, "error": str(exc)})
+
+    # Verification: re-fetch each affected user record so the caller can
+    # confirm enabled/lockedOut/loginFailures fields reflect the change.
+    verification: list[dict] = []
+    for uid in ids:
+        try:
+            user = session.request("GET", f"/v1/users/{uid}").json()
+            verification.append(
+                {
+                    "userId": uid,
+                    "enabled": user.get("enabled"),
+                    "isLockedOut": user.get("isLockedOut"),
+                    "lastLogin": user.get("lastLogin"),
+                }
+            )
+        except Exception as exc:  # pragma: no cover - network failures
+            verification.append({"userId": uid, "error": str(exc)})
+
+    return {
+        "result": {
+            "scenario": scenario,
+            "user_ids": ids,
+            "comment": comment,
+            "steps": per_step,
+            "all_ok": all(s["ok"] for s in per_step),
+        },
+        "verification": verification,
+    }
+
+
 TOOLS = [
     ("search", search),
     ("fetch", fetch),
@@ -1849,7 +2047,6 @@ TOOLS = [
     ("list_example_reports", list_example_reports),
     ("get_secret", get_secret),
     ("get_folder", get_folder),
-    ("user_management", user_management),
     ("role_management", role_management),
     ("user_role_management", user_role_management),
     ("group_management", group_management),
@@ -1857,7 +2054,6 @@ TOOLS = [
     ("group_role_management", group_role_management),
     ("folder_management", folder_management),
     ("health_check", health_check),
-    ("search_users", search_users),
     ("search_secrets", search_secrets),
     ("search_folders", search_folders),
     ("get_secret_environment_variable", get_secret_environment_variable),
@@ -1877,6 +2073,9 @@ TOOLS = [
         set_secret_field_environment_variable,
     ),
     ("update_secret_generated_password", update_secret_generated_password),
+    # New in v1.0.0: secret editing flow and bulk user incident response.
+    ("update_secret_fields", update_secret_fields),
+    ("bulk_user_response", bulk_user_response),
 ]
 
 

--- a/delinea_mcp/user_platform_tools.py
+++ b/delinea_mcp/user_platform_tools.py
@@ -150,7 +150,22 @@ def _build_headers() -> dict[str, str]:
 
 
 def _platform_url(path: str) -> str:
-    return f"https://{platform_hostname}/identity{path}"
+    """Build a Platform identity-API URL.
+
+    Modern Delinea Platform tenants serve all identity-API endpoints under
+    ``/identity/api/...``.  Accept paths in two forms:
+
+    * ``"/UserMgmt/GetUserAttributes"`` — auto-prefixed with ``/identity/api``.
+    * ``"/identity/api/..."`` — used verbatim (compat with older code that
+      already hard-coded the prefix).
+    """
+    if path.startswith("/identity/"):
+        return f"https://{platform_hostname}{path}"
+    if path.startswith("/api/"):
+        # Old code shape: ``/api/Report/RunReport`` → ``/identity/api/...``
+        return f"https://{platform_hostname}/identity{path}"
+    # New shape: bare endpoint name → ``/identity/api/<endpoint>``
+    return f"https://{platform_hostname}/identity/api{path}"
 
 
 # --------------------------------------------------------------------------- #
@@ -284,11 +299,14 @@ def user_management(
         if action == "get":
             if not user_id:
                 raise ValueError("user_id required for get")
-            url = _platform_url("/UserMgmt/GetUser")
-            response = requests.get(
+            # Modern Delinea Platform exposes /identity/api/UserMgmt/GetUserAttributes
+            # (POST, body {"ID": <uuid>}) — the legacy /UserMgmt/GetUser GET endpoint
+            # was removed.  GetUserAttributes returns a richer record.
+            url = _platform_url("/UserMgmt/GetUserAttributes")
+            response = requests.post(
                 url,
+                json={"ID": user_id},
                 headers=headers,
-                params={"userId": user_id},
                 timeout=_DEFAULT_TIMEOUT,
             )
             return _json_or_error(response)
@@ -359,46 +377,100 @@ def platform_user_management(*args, **kwargs):
 # --------------------------------------------------------------------------- #
 
 
+_ROLE_SEARCH_REPORT_ID = "role_searchbyname"
+
+
+def _run_role_search_report(
+    headers: dict[str, str], query: str = "%", page_size: int = 100
+) -> dict:
+    """Run the ``role_searchbyname`` canned report.
+
+    The modern Delinea Platform exposes role data through this report
+    rather than via dedicated REST endpoints or Redrock SQL.  The shape
+    mirrors :func:`search_users` exactly.
+    """
+    url = _platform_url("/Report/RunReport")
+    payload = {
+        "ID": _ROLE_SEARCH_REPORT_ID,
+        "Args": {
+            "PageNumber": 1,
+            "PageSize": page_size,
+            "Limit": 100000,
+            "FilterQuery": None,
+            "Caching": 0,
+            "Ascending": True,
+            "SortBy": "Name",
+            "Parameters": [
+                {
+                    "Name": "searchString",
+                    "Value": query,
+                    "Label": "searchString",
+                    "Type": "string",
+                    "ColumnType": 12,
+                },
+                {
+                    "Name": "orderby",
+                    "Value": "Name",
+                    "Label": "orderby",
+                    "Type": "string",
+                    "ColumnType": 12,
+                },
+            ],
+        },
+    }
+    return _json_or_error(
+        requests.post(url, json=payload, headers=headers, timeout=_DEFAULT_TIMEOUT)
+    )
+
+
+_ROLE_WRITE_NOT_SUPPORTED = (
+    "Platform role write operations (create/update/delete) are not exposed "
+    "through the xpmheadless OAuth scope on modern Delinea Platform tenants — "
+    "the legacy SaasManage/StoreRole + Roles/UpdateRole endpoints return 404. "
+    "Use the Secret-Server-backed role_management tool to manage roles in "
+    "mixed Platform/SS deployments, or open the tenant's admin UI directly."
+)
+
+
 def platform_role_management(
     action: str,
     role_id: str | None = None,
-    data: dict | str | None = None,
+    data: dict | str | None = None,  # noqa: ARG001 — accepted for parity with SS API
     *,
     page_size: int = 100,
+    query: str = "%",
 ) -> dict:
-    """Manage roles on the Delinea Platform identity service.
+    """Read roles on the Delinea Platform identity service.
 
-    Endpoint coverage:
+    Endpoint coverage on **modern Delinea Platform** tenants:
 
-    * ``"create"`` -> ``POST /identity/SaasManage/StoreRole`` with body
-      ``{"Name": ..., "Description": ...}``.
-      Returns the role identifier in ``Result._RowKey``.
-    * ``"update"`` -> ``POST /identity/Roles/UpdateRole`` with body
-      ``{"Name": <role-id>, "Description": ..., "Users": {"Add": [...], "Delete": [...]}}``.
-    * ``"list"`` -> ``POST /identity/Redrock/Query`` with the role-listing
-      script.
-    * ``"get"`` -> ``POST /identity/Redrock/Query`` filtered to the role id.
-    * ``"delete"`` -> ``POST /identity/SaasManage/RemoveRole`` body
-      ``{"Name": <role-id>}``.
+    * ``"list"`` -> ``POST /identity/api/Report/RunReport`` ID
+      ``role_searchbyname`` with a wildcard match.  Returns all visible roles.
+    * ``"get"`` -> same report filtered by exact role name (since the modern
+      Platform doesn't expose a Redrock SQL endpoint to filter by ID).
+    * ``"create"``/``"update"``/``"delete"`` — **not supported** on modern
+      tenants via this scope.  Returns a structured error pointing the caller
+      at :func:`delinea_mcp.tools.role_management` (which manages roles
+      through Secret Server's ``/v1/roles`` API in mixed deployments).
 
     Parameters
     ----------
     action:
-        ``"list"``, ``"get"``, ``"create"``, ``"update"`` or ``"delete"``.
+        ``"list"`` or ``"get"`` (read).  ``"create"``/``"update"``/``"delete"``
+        return an "unsupported" error on modern Platform tenants.
     role_id:
-        Required for ``"get"``, ``"update"`` and ``"delete"``.  This is the
-        Platform's role identifier (a string ``_RowKey`` returned by
-        ``StoreRole`` — *not* a numeric SS role id).
-    data:
-        For ``"create"``: ``{"Name": ..., "Description": ...}``.
-        For ``"update"``: any subset of ``{"Description", "Name",
-        "Users": {"Add": [...], "Delete": [...]}, "Roles": {"Add": [...]}}``.
+        For ``"get"``: the role's Name (modern Platform) or ID (legacy).
+        The canned report matches against ``Name``.
+    page_size:
+        Maximum rows for ``"list"``.
+    query:
+        Optional search substring for ``"list"``.  Default ``"%"`` matches all.
 
     Returns
     -------
     dict
-        Raw API payload or ``{"result": ..., "verification": ...}`` for
-        write actions.
+        Raw report payload for ``"list"``/``"get"``; ``{"error": ...}`` for
+        unsupported write actions.
     """
 
     logger.debug("platform_role_management(action=%s, role_id=%s)", action, role_id)
@@ -408,79 +480,20 @@ def platform_role_management(
     except RuntimeError as exc:
         return {"error": str(exc)}
 
-    payload = _parse_json_data(data)
-
     try:
         if action == "list":
-            url = _platform_url("/Redrock/Query")
-            body = {
-                "Script": (
-                    "SELECT ID, Name, Description FROM Role "
-                    "ORDER BY Name COLLATE NOCASE"
-                ),
-                "Args": {"PageNumber": 1, "PageSize": page_size},
-            }
-            return _json_or_error(
-                requests.post(url, json=body, headers=headers, timeout=_DEFAULT_TIMEOUT)
-            )
+            return _run_role_search_report(headers, query=query, page_size=page_size)
 
         if action == "get":
             if not role_id:
                 raise ValueError("role_id required for get")
-            url = _platform_url("/Redrock/Query")
-            # Parameterise to avoid script injection.
-            body = {
-                "Script": ("SELECT ID, Name, Description FROM Role WHERE ID = @rid"),
-                "Args": {
-                    "PageNumber": 1,
-                    "PageSize": 1,
-                    "Parameters": [{"Name": "rid", "Value": role_id, "Type": "string"}],
-                },
-            }
-            return _json_or_error(
-                requests.post(url, json=body, headers=headers, timeout=_DEFAULT_TIMEOUT)
-            )
+            # The canned report filters on Name (case-insensitive substring).
+            # For modern tenants role_id is typically a Name; for legacy IDs
+            # callers can pass the ID and rely on Name = ID for system roles.
+            return _run_role_search_report(headers, query=str(role_id), page_size=10)
 
-        if action == "create":
-            if payload is None or not payload.get("Name"):
-                raise ValueError("data with 'Name' required for create")
-            url = _platform_url("/SaasManage/StoreRole")
-            resp = requests.post(
-                url, json=payload, headers=headers, timeout=_DEFAULT_TIMEOUT
-            )
-            result = _json_or_error(resp)
-            new_id = (
-                (result.get("Result") or {}).get("_RowKey")
-                if isinstance(result.get("Result"), dict)
-                else None
-            )
-            verify: dict[str, Any] = {}
-            if new_id:
-                verify = platform_role_management("get", role_id=new_id)
-            return {"result": result, "verification": verify}
-
-        if action == "update":
-            if not role_id or payload is None:
-                raise ValueError("role_id and data required for update")
-            url = _platform_url("/Roles/UpdateRole")
-            body = {"Name": role_id, **payload}
-            resp = requests.post(
-                url, json=body, headers=headers, timeout=_DEFAULT_TIMEOUT
-            )
-            result = _json_or_error(resp)
-            verify = platform_role_management("get", role_id=role_id)
-            return {"result": result, "verification": verify}
-
-        if action == "delete":
-            if not role_id:
-                raise ValueError("role_id required for delete")
-            url = _platform_url("/SaasManage/RemoveRole")
-            resp = requests.post(
-                url, json={"Name": role_id}, headers=headers, timeout=_DEFAULT_TIMEOUT
-            )
-            result = _json_or_error(resp)
-            verify = platform_role_management("get", role_id=role_id)
-            return {"result": result, "verification": verify}
+        if action in ("create", "update", "delete"):
+            return {"error": _ROLE_WRITE_NOT_SUPPORTED}
 
         raise ValueError(f"Unknown action: {action}")
     except Exception as exc:  # pragma: no cover - network failures
@@ -488,32 +501,48 @@ def platform_role_management(
         return {"error": str(exc)}
 
 
+_USER_ROLE_WRITE_NOT_SUPPORTED = (
+    "Platform user-role membership mutations (add/remove) are not exposed "
+    "through the xpmheadless OAuth scope on modern Delinea Platform tenants — "
+    "the legacy Roles/UpdateRole endpoint returns 404. Use the "
+    "Secret-Server-backed user_role_management tool, which manages the "
+    "SS-side role wiring that Platform tenants typically mirror, or the "
+    "Platform admin UI directly."
+)
+
+
 def platform_user_role_management(
     action: str,
     role_id: str,
     user_principals: list[str] | str | None = None,
 ) -> dict:
-    """Add or remove users from a Platform role.
+    """Read users assigned to a Platform role.
 
-    Implemented via ``POST /identity/Roles/UpdateRole`` with a body of
-    ``{"Name": <role_id>, "Users": {"Add": [...], "Delete": [...]}}``.
+    On **modern Delinea Platform** tenants:
+
+    * ``"list"`` -> ``POST /identity/api/Report/RunReport`` ID
+      ``user_searchbyname`` (the canned report doesn't filter by role
+      directly; this returns *all* users — callers should use
+      :func:`search_users` instead and look at the ``Roles`` column there
+      if their tenant exposes it).
+    * ``"add"``/``"remove"`` — **not supported** via the xpmheadless scope.
+      Returns a structured error pointing at SS-side ``user_role_management``.
 
     Parameters
     ----------
     action:
-        ``"add"``, ``"remove"`` or ``"list"`` (lists current role members).
+        ``"add"``, ``"remove"`` or ``"list"``.
     role_id:
-        Platform role identifier (the ``_RowKey`` returned by ``StoreRole``).
+        Platform role name/identifier.
     user_principals:
-        For ``"add"``/``"remove"``: list of user principal names (e.g.
-        ``"alice@tenant"``) or user IDs.  Accepts a JSON-encoded string too.
-        Ignored for ``"list"``.
+        Ignored for ``"list"``; required for ``"add"``/``"remove"`` (but
+        those return an unsupported-on-this-tenant error).
 
     Returns
     -------
     dict
-        For ``"list"``: raw response payload listing role members.
-        For ``"add"``/``"remove"``: ``{"result": ..., "verification": ...}``.
+        For ``"list"``: passthrough of the report payload.
+        For mutations: ``{"error": ...}`` with a clear remediation pointer.
     """
 
     logger.debug(
@@ -533,36 +562,13 @@ def platform_user_role_management(
 
     try:
         if action == "list":
-            url = _platform_url("/Redrock/Query")
-            # Roles → RoleMembers join: ask the Platform for the principals.
-            body = {
-                "Script": (
-                    "SELECT u.Username, u.ID FROM User u "
-                    "INNER JOIN RoleMember rm ON rm.UserID = u.ID "
-                    "WHERE rm.RoleID = @rid"
-                ),
-                "Args": {
-                    "PageNumber": 1,
-                    "PageSize": 200,
-                    "Parameters": [{"Name": "rid", "Value": role_id, "Type": "string"}],
-                },
-            }
-            return _json_or_error(
-                requests.post(url, json=body, headers=headers, timeout=_DEFAULT_TIMEOUT)
-            )
+            # Look up role-by-name then return any membership info the report
+            # exposes.  The canned report returns roletype + description; some
+            # tenants augment with a 'members' field.
+            return _run_role_search_report(headers, query=str(role_id), page_size=50)
 
         if action in ("add", "remove"):
-            if not user_principals:
-                raise ValueError(f"user_principals required for {action}")
-            key = "Add" if action == "add" else "Delete"
-            url = _platform_url("/Roles/UpdateRole")
-            body = {"Name": role_id, "Users": {key: list(user_principals)}}
-            resp = requests.post(
-                url, json=body, headers=headers, timeout=_DEFAULT_TIMEOUT
-            )
-            result = _json_or_error(resp)
-            verify = platform_user_role_management("list", role_id=role_id)
-            return {"result": result, "verification": verify}
+            return {"error": _USER_ROLE_WRITE_NOT_SUPPORTED}
 
         raise ValueError(f"Unknown action: {action}")
     except Exception as exc:  # pragma: no cover - network failures

--- a/delinea_mcp/user_platform_tools.py
+++ b/delinea_mcp/user_platform_tools.py
@@ -55,6 +55,18 @@ def _json_or_error(response: requests.Response) -> dict:
         return {"error": response.text}
 
 
+def _endpoint_not_available(response: requests.Response) -> bool:
+    """Return True when *response* looks like 'endpoint not in this scope'.
+
+    On modern Delinea Platform tenants the legacy role-management endpoints
+    return a bare 404 with an empty body.  Older Centrify deployments
+    return a JSON envelope with ``success=False`` and a descriptive
+    message.  We treat any 404 as "not available" — the tools fall back to
+    a structured guidance error in that case.
+    """
+    return response.status_code == 404
+
+
 platform_hostname = os.getenv("PLATFORM_HOSTNAME")
 platform_service_account = os.getenv("PLATFORM_SERVICE_ACCOUNT")
 platform_service_password = os.getenv("PLATFORM_SERVICE_PASSWORD")
@@ -424,43 +436,56 @@ def _run_role_search_report(
 
 
 _ROLE_WRITE_NOT_SUPPORTED = (
-    "Platform role write operations (create/update/delete) are not exposed "
-    "through the xpmheadless OAuth scope on modern Delinea Platform tenants — "
-    "the legacy SaasManage/StoreRole + Roles/UpdateRole endpoints return 404. "
-    "Use the Secret-Server-backed role_management tool to manage roles in "
-    "mixed Platform/SS deployments, or open the tenant's admin UI directly."
+    "Platform role write endpoint returned 404 — this OAuth scope on this "
+    "tenant does not expose role mutations (typical on modern Delinea Platform "
+    "deployments using the xpmheadless scope). Use the Secret-Server-backed "
+    "role_management tool to manage roles in mixed Platform/SS deployments, "
+    "or open the tenant's admin UI directly."
 )
 
 
 def platform_role_management(
     action: str,
     role_id: str | None = None,
-    data: dict | str | None = None,  # noqa: ARG001 — accepted for parity with SS API
+    data: dict | str | None = None,
     *,
     page_size: int = 100,
     query: str = "%",
 ) -> dict:
-    """Read roles on the Delinea Platform identity service.
+    """Manage roles on the Delinea Platform identity service.
 
-    Endpoint coverage on **modern Delinea Platform** tenants:
+    Endpoint coverage:
 
     * ``"list"`` -> ``POST /identity/api/Report/RunReport`` ID
       ``role_searchbyname`` with a wildcard match.  Returns all visible roles.
-    * ``"get"`` -> same report filtered by exact role name (since the modern
-      Platform doesn't expose a Redrock SQL endpoint to filter by ID).
-    * ``"create"``/``"update"``/``"delete"`` — **not supported** on modern
-      tenants via this scope.  Returns a structured error pointing the caller
-      at :func:`delinea_mcp.tools.role_management` (which manages roles
-      through Secret Server's ``/v1/roles`` API in mixed deployments).
+    * ``"get"`` -> same report filtered by an exact / substring role name.
+    * ``"create"`` -> ``POST /identity/api/SaasManage/StoreRole`` (body
+      ``{"Name": ..., "Description": ...}``).  Returns the role's
+      ``_RowKey`` in ``Result``.
+    * ``"update"`` -> ``POST /identity/api/Roles/UpdateRole`` (body
+      ``{"Name": <role-id>, "Description": ..., "Users": {"Add": [...]}, ...}``).
+    * ``"delete"`` -> ``POST /identity/api/SaasManage/RemoveRole``.
+
+    Mutation behaviour is **discovery-driven**: the tool attempts the
+    documented endpoint, and only falls back to a structured guidance
+    error when the response is HTTP 404 (typical on modern Delinea
+    Platform tenants using the ``xpmheadless`` scope, which exposes
+    user CRUD but not role CRUD).  Tenants that do expose role
+    mutations get the real result.
 
     Parameters
     ----------
     action:
-        ``"list"`` or ``"get"`` (read).  ``"create"``/``"update"``/``"delete"``
-        return an "unsupported" error on modern Platform tenants.
+        ``"list"``, ``"get"``, ``"create"``, ``"update"`` or ``"delete"``.
     role_id:
-        For ``"get"``: the role's Name (modern Platform) or ID (legacy).
-        The canned report matches against ``Name``.
+        Required for ``"get"``, ``"update"`` and ``"delete"``.  For
+        modern Platform this is typically a Name; for legacy Centrify
+        deployments it's the ``_RowKey`` returned by ``StoreRole``.
+    data:
+        For ``"create"``: ``{"Name": ..., "Description": ...}``.
+        For ``"update"``: any subset of
+        ``{"Description", "Name", "Users": {"Add": [...], "Delete": [...]},
+        "Roles": {"Add": [...]}}``.
     page_size:
         Maximum rows for ``"list"``.
     query:
@@ -469,8 +494,9 @@ def platform_role_management(
     Returns
     -------
     dict
-        Raw report payload for ``"list"``/``"get"``; ``{"error": ...}`` for
-        unsupported write actions.
+        Raw API payload for reads, ``{"result": ..., "verification": ...}``
+        for successful writes, or ``{"error": ...}`` when the endpoint is
+        unavailable on this tenant.
     """
 
     logger.debug("platform_role_management(action=%s, role_id=%s)", action, role_id)
@@ -479,6 +505,8 @@ def platform_role_management(
         headers = _build_headers()
     except RuntimeError as exc:
         return {"error": str(exc)}
+
+    payload = _parse_json_data(data)
 
     try:
         if action == "list":
@@ -492,8 +520,54 @@ def platform_role_management(
             # callers can pass the ID and rely on Name = ID for system roles.
             return _run_role_search_report(headers, query=str(role_id), page_size=10)
 
-        if action in ("create", "update", "delete"):
-            return {"error": _ROLE_WRITE_NOT_SUPPORTED}
+        if action == "create":
+            if payload is None or not payload.get("Name"):
+                raise ValueError("data with 'Name' required for create")
+            url = _platform_url("/SaasManage/StoreRole")
+            resp = requests.post(
+                url, json=payload, headers=headers, timeout=_DEFAULT_TIMEOUT
+            )
+            if _endpoint_not_available(resp):
+                return {"error": _ROLE_WRITE_NOT_SUPPORTED}
+            result = _json_or_error(resp)
+            new_id = None
+            if isinstance(result, dict):
+                r = result.get("Result")
+                if isinstance(r, str):
+                    new_id = r
+                elif isinstance(r, dict):
+                    new_id = r.get("_RowKey") or r.get("ID") or r.get("Name")
+            verify: dict[str, Any] = {}
+            if new_id:
+                verify = platform_role_management("get", role_id=new_id)
+            return {"result": result, "verification": verify}
+
+        if action == "update":
+            if not role_id or payload is None:
+                raise ValueError("role_id and data required for update")
+            url = _platform_url("/Roles/UpdateRole")
+            body = {"Name": role_id, **payload}
+            resp = requests.post(
+                url, json=body, headers=headers, timeout=_DEFAULT_TIMEOUT
+            )
+            if _endpoint_not_available(resp):
+                return {"error": _ROLE_WRITE_NOT_SUPPORTED}
+            result = _json_or_error(resp)
+            verify = platform_role_management("get", role_id=role_id)
+            return {"result": result, "verification": verify}
+
+        if action == "delete":
+            if not role_id:
+                raise ValueError("role_id required for delete")
+            url = _platform_url("/SaasManage/RemoveRole")
+            resp = requests.post(
+                url, json={"Name": role_id}, headers=headers, timeout=_DEFAULT_TIMEOUT
+            )
+            if _endpoint_not_available(resp):
+                return {"error": _ROLE_WRITE_NOT_SUPPORTED}
+            result = _json_or_error(resp)
+            verify = platform_role_management("get", role_id=role_id)
+            return {"result": result, "verification": verify}
 
         raise ValueError(f"Unknown action: {action}")
     except Exception as exc:  # pragma: no cover - network failures
@@ -502,9 +576,9 @@ def platform_role_management(
 
 
 _USER_ROLE_WRITE_NOT_SUPPORTED = (
-    "Platform user-role membership mutations (add/remove) are not exposed "
-    "through the xpmheadless OAuth scope on modern Delinea Platform tenants — "
-    "the legacy Roles/UpdateRole endpoint returns 404. Use the "
+    "Platform user-role mutation endpoint returned 404 — this OAuth scope on "
+    "this tenant does not expose role-membership writes (typical on modern "
+    "Delinea Platform deployments using the xpmheadless scope). Use the "
     "Secret-Server-backed user_role_management tool, which manages the "
     "SS-side role wiring that Platform tenants typically mirror, or the "
     "Platform admin UI directly."
@@ -516,17 +590,19 @@ def platform_user_role_management(
     role_id: str,
     user_principals: list[str] | str | None = None,
 ) -> dict:
-    """Read users assigned to a Platform role.
-
-    On **modern Delinea Platform** tenants:
+    """Add, remove, or list users assigned to a Platform role.
 
     * ``"list"`` -> ``POST /identity/api/Report/RunReport`` ID
-      ``user_searchbyname`` (the canned report doesn't filter by role
-      directly; this returns *all* users — callers should use
-      :func:`search_users` instead and look at the ``Roles`` column there
-      if their tenant exposes it).
-    * ``"add"``/``"remove"`` — **not supported** via the xpmheadless scope.
-      Returns a structured error pointing at SS-side ``user_role_management``.
+      ``role_searchbyname`` (filtered to *role_id*).  Returns the role's
+      row; some tenants include a ``members`` column there.  Callers can
+      cross-reference with :func:`search_users`.
+    * ``"add"``/``"remove"`` -> ``POST /identity/api/Roles/UpdateRole`` with
+      body ``{"Name": <role_id>, "Users": {"Add": [...]}}`` or
+      ``{"Users": {"Delete": [...]}}``.
+
+    Mutation behaviour is **discovery-driven**: the tool attempts the
+    documented endpoint and only falls back to a structured guidance
+    error when the response is HTTP 404.
 
     Parameters
     ----------
@@ -535,14 +611,15 @@ def platform_user_role_management(
     role_id:
         Platform role name/identifier.
     user_principals:
-        Ignored for ``"list"``; required for ``"add"``/``"remove"`` (but
-        those return an unsupported-on-this-tenant error).
+        For ``"add"``/``"remove"``: list of user principal names (e.g.
+        ``"alice@tenant"``) or UUIDs.  Accepts a JSON-encoded string too.
 
     Returns
     -------
     dict
-        For ``"list"``: passthrough of the report payload.
-        For mutations: ``{"error": ...}`` with a clear remediation pointer.
+        Report payload for ``"list"``; ``{"result": ..., "verification": ...}``
+        for successful writes; ``{"error": ...}`` when the endpoint is
+        unavailable on this tenant.
     """
 
     logger.debug(
@@ -568,7 +645,19 @@ def platform_user_role_management(
             return _run_role_search_report(headers, query=str(role_id), page_size=50)
 
         if action in ("add", "remove"):
-            return {"error": _USER_ROLE_WRITE_NOT_SUPPORTED}
+            if not user_principals:
+                raise ValueError(f"user_principals required for {action}")
+            key = "Add" if action == "add" else "Delete"
+            url = _platform_url("/Roles/UpdateRole")
+            body = {"Name": role_id, "Users": {key: list(user_principals)}}
+            resp = requests.post(
+                url, json=body, headers=headers, timeout=_DEFAULT_TIMEOUT
+            )
+            if _endpoint_not_available(resp):
+                return {"error": _USER_ROLE_WRITE_NOT_SUPPORTED}
+            result = _json_or_error(resp)
+            verify = platform_user_role_management("list", role_id=role_id)
+            return {"result": result, "verification": verify}
 
         raise ValueError(f"Unknown action: {action}")
     except Exception as exc:  # pragma: no cover - network failures

--- a/delinea_mcp/user_platform_tools.py
+++ b/delinea_mcp/user_platform_tools.py
@@ -1,10 +1,37 @@
+"""Delinea Platform identity-API tooling.
+
+Modern Delinea cloud deployments authenticate users via the Delinea
+Platform identity provider.  This module exposes the canonical user,
+role, and search tools that operate against the Platform's identity
+endpoints (``/identity/...``).
+
+In v1.0.0 the canonical names ``user_management`` and ``search_users``
+were promoted from this module.  The previous Secret-Server-local
+implementations are preserved under
+:mod:`delinea_mcp.secretserver_users` as ``secretserver_local_*`` for
+SS-only on-prem deployments.
+
+Endpoint references
+-------------------
+
+* ``POST /identity/CDirectoryService/CreateUser`` — create user
+* ``POST /identity/CDirectoryService/ChangeUser`` — update user
+* ``GET  /identity/UserMgmt/GetUser?userId=<id>`` — get user
+* ``POST /identity/UserMgmt/RemoveUsers`` body ``{"Users":[id]}`` — delete
+* ``POST /identity/api/Report/RunReport`` — search via canned reports
+* ``POST /identity/SaasManage/StoreRole`` — create role
+  (https://developer.delinea.com/docs/manage-rolesnew)
+* ``POST /identity/Roles/UpdateRole`` — update role + add/remove members
+* ``POST /identity/Redrock/Query`` — generic SQL-like query for users,
+  roles, groups
 """
-MCP tools for Platform User API integration.
-"""
+
+from __future__ import annotations
 
 import json
 import logging
 import os
+from typing import Any
 
 import requests
 
@@ -12,7 +39,6 @@ logger = logging.getLogger(__name__)
 
 
 def _parse_json_data(data: dict | str | None) -> dict | None:
-    """Return a dict from ``data`` when given a JSON string."""
     if isinstance(data, str):
         try:
             return json.loads(data)
@@ -34,6 +60,12 @@ platform_service_account = os.getenv("PLATFORM_SERVICE_ACCOUNT")
 platform_service_password = os.getenv("PLATFORM_SERVICE_PASSWORD")
 platform_tenant_id = os.getenv("PLATFORM_TENANT_ID")
 
+# Default request timeout for all Platform API calls.  Override per-process
+# with the ``PLATFORM_TIMEOUT`` environment variable.  Without this the
+# requests library blocks indefinitely on a hung TCP connection — bad for
+# both interactive sessions and CI.
+_DEFAULT_TIMEOUT = float(os.getenv("PLATFORM_TIMEOUT", "30"))
+
 
 def configure(
     hostname: str | None = None,
@@ -51,16 +83,37 @@ def configure(
         platform_service_password = service_password
     if tenant_id is not None:
         platform_tenant_id = tenant_id
+    # Invalidate cached headers so re-configuration takes effect.
+    global _headers
+    _headers = None
 
 
-_headers = None
+_headers: dict[str, str] | None = None
 
 
-def _build_headers():
+def _platform_configured() -> bool:
+    return bool(
+        platform_hostname and platform_service_account and platform_service_password
+    )
+
+
+_NOT_CONFIGURED_ERROR = (
+    "Platform is not configured. This tool requires PLATFORM_HOSTNAME, "
+    "PLATFORM_SERVICE_ACCOUNT, PLATFORM_SERVICE_PASSWORD (and typically "
+    "PLATFORM_TENANT_ID) to be set, or the equivalent keys in config.json. "
+    "For SS-only deployments, use secretserver_local_user_management / "
+    "search_secretserver_local_users instead."
+)
+
+
+def _build_headers() -> dict[str, str]:
     """Return cached headers or fetch a new OAuth token using ``requests``."""
     global _headers
     if _headers:
         return _headers
+
+    if not _platform_configured():
+        raise RuntimeError(_NOT_CONFIGURED_ERROR)
 
     url = f"https://{platform_hostname}/identity/api/oauth2/token/xpmplatform"
     data = {
@@ -74,6 +127,7 @@ def _build_headers():
             url,
             data=data,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=_DEFAULT_TIMEOUT,
         )
     except Exception as exc:
         logger.error("Failed to get token: %s", exc)
@@ -85,33 +139,54 @@ def _build_headers():
 
     token_data = response.json()
     access_token = token_data["access_token"]
-    _headers = {
+    headers = {
         "Authorization": f"Bearer {access_token}",
         "Content-Type": "application/json",
-        "X-MT-SecondaryId": f"{platform_tenant_id}",
     }
+    if platform_tenant_id:
+        headers["X-MT-SecondaryId"] = f"{platform_tenant_id}"
+    _headers = headers
     return _headers
 
 
-def search_platform_user(username: str) -> dict:
-    """Search for a user in the Platform by username.
+def _platform_url(path: str) -> str:
+    return f"https://{platform_hostname}/identity{path}"
+
+
+# --------------------------------------------------------------------------- #
+# Users (canonical user_management / search_users)                            #
+# --------------------------------------------------------------------------- #
+
+
+def search_users(query: str) -> dict:
+    """Search the Platform identity directory for users.
+
+    Calls ``POST /identity/api/Report/RunReport`` with the
+    ``user_searchbyname`` canned report.  Returns the raw report payload.
+
+    For SS-only deployments without Platform configured, use
+    :func:`delinea_mcp.secretserver_users.search_secretserver_local_users`.
 
     Parameters
     ----------
-    username:
-        Username to search for.
+    query:
+        Text to search for in usernames.
 
     Returns
     -------
     dict
-        JSON response from the platform user search report.
+        JSON response from the platform user search report or
+        ``{"error": ...}``.
     """
 
-    if not username:
-        return {"error": "username required for search"}
+    if not query:
+        return {"error": "query required"}
+    try:
+        headers = _build_headers()
+    except RuntimeError as exc:
+        return {"error": str(exc)}
 
-    headers = _build_headers()
-    url = f"https://{platform_hostname}/identity/api/Report/RunReport"
+    url = _platform_url("/api/Report/RunReport")
     payload = {
         "ID": "user_searchbyname",
         "Args": {
@@ -125,7 +200,7 @@ def search_platform_user(username: str) -> dict:
             "Parameters": [
                 {
                     "Name": "searchString",
-                    "Value": f"%{username}%",
+                    "Value": f"%{query}%",
                     "Label": "searchString",
                     "Type": "string",
                     "ColumnType": 12,
@@ -141,27 +216,43 @@ def search_platform_user(username: str) -> dict:
         },
     }
     try:
-        response = requests.post(url, headers=headers, json=payload)
+        response = requests.post(
+            url, headers=headers, json=payload, timeout=_DEFAULT_TIMEOUT
+        )
     except Exception as exc:
-        logger.exception("Failed to search platform user")
+        logger.exception("Failed to search platform users")
         return {"error": str(exc)}
     return _json_or_error(response)
 
 
-def platform_user_management(
+# Back-compat alias used by tests and older callers.
+def search_platform_user(username: str) -> dict:
+    """Alias for :func:`search_users`. Retained for back-compat."""
+    return search_users(username)
+
+
+def user_management(
     action: str,
     user_id: str | None = None,
     data: dict | str | None = None,
     username: str | None = None,
 ) -> dict:
-    """Manage users on Delinea Platform via a unified helper.
+    """Manage users on the Delinea Platform via a unified helper.
+
+    This is the **canonical** ``user_management`` tool (v1.0.0+).  It
+    talks to the Platform identity API, which is the authoritative user
+    store in cloud-native and Platform-integrated tenants.
+
+    For SS-only deployments without Platform configured, use
+    :func:`delinea_mcp.secretserver_users.secretserver_local_user_management`.
 
     Parameters
     ----------
     action:
-        One of ``"create"``, ``"delete"``, ``"update"``, ``"get"`` or ``"search"``.
+        One of ``"create"``, ``"delete"``, ``"update"``, ``"get"`` or
+        ``"search"``.
     user_id:
-        Identifier used with ``"update"``, ``"delete"`` and ``"get"`` actions.
+        Identifier used with ``"update"``, ``"delete"`` and ``"get"``.
     data:
         JSON body for ``"create"`` and ``"update"``.
     username:
@@ -170,61 +261,73 @@ def platform_user_management(
     Returns
     -------
     dict
-        Response payload or ``{"result": ..., "verification": ...}`` when a
-        verifying lookup is performed.
+        Response payload or ``{"result": ..., "verification": ...}`` when
+        a verifying lookup is performed.
     """
 
     logger.debug(
-        "platform_user_management(action=%s, user_id=%s, username=%s, data=%s)",
+        "user_management(action=%s, user_id=%s, username=%s, data=%s)",
         action,
         user_id,
         username,
         data,
     )
 
-    headers = _build_headers()
+    try:
+        headers = _build_headers()
+    except RuntimeError as exc:
+        return {"error": str(exc)}
+
     payload = _parse_json_data(data)
 
     try:
         if action == "get":
             if not user_id:
                 raise ValueError("user_id required for get")
-            url = f"https://{platform_hostname}/identity/UserMgmt/GetUser"
+            url = _platform_url("/UserMgmt/GetUser")
             response = requests.get(
                 url,
                 headers=headers,
                 params={"userId": user_id},
+                timeout=_DEFAULT_TIMEOUT,
             )
             return _json_or_error(response)
 
         if action == "create":
             if payload is None:
                 raise ValueError("data required for create")
-            url = f"https://{platform_hostname}/identity/CDirectoryService/CreateUser"
-            response = requests.post(url, json=payload, headers=headers)
-            result = _json_or_error(response)
-            verify = search_platform_user(
-                payload.get("Name") or payload.get("Username") or ""
+            url = _platform_url("/CDirectoryService/CreateUser")
+            response = requests.post(
+                url, json=payload, headers=headers, timeout=_DEFAULT_TIMEOUT
             )
+            result = _json_or_error(response)
+            verify = search_users(payload.get("Name") or payload.get("Username") or "")
             return {"result": result, "verification": verify}
 
         if action == "delete":
             if not user_id:
                 raise ValueError("user_id required for delete")
-            url = f"https://{platform_hostname}/identity/UserMgmt/RemoveUsers"
-            response = requests.post(url, json={"Users": [user_id]}, headers=headers)
+            url = _platform_url("/UserMgmt/RemoveUsers")
+            response = requests.post(
+                url,
+                json={"Users": [user_id]},
+                headers=headers,
+                timeout=_DEFAULT_TIMEOUT,
+            )
             result = _json_or_error(response)
-            verify = search_platform_user(user_id)
+            verify = search_users(user_id)
             return {"result": result, "verification": verify}
 
         if action == "update":
             if not user_id or payload is None:
                 raise ValueError("user_id and data required for update")
             payload.setdefault("ID", user_id)
-            url = f"https://{platform_hostname}/identity/CDirectoryService/ChangeUser"
-            response = requests.post(url, json=payload, headers=headers)
+            url = _platform_url("/CDirectoryService/ChangeUser")
+            response = requests.post(
+                url, json=payload, headers=headers, timeout=_DEFAULT_TIMEOUT
+            )
             result = _json_or_error(response)
-            verify = search_platform_user(
+            verify = search_users(
                 payload.get("Name") or payload.get("Username") or user_id
             )
             return {"result": result, "verification": verify}
@@ -232,20 +335,265 @@ def platform_user_management(
         if action == "search":
             if username is None:
                 raise ValueError("username required for search")
-            return search_platform_user(username)
+            return search_users(username)
 
         raise ValueError(f"Unknown action: {action}")
 
     except Exception as exc:  # pragma: no cover - network failures
-        logger.exception("Platform user management action failed")
+        logger.exception("Platform user_management action failed")
         return {"error": str(exc)}
 
 
+# Deprecated alias: keeps existing callers working but discouraged in v1+.
+def platform_user_management(*args, **kwargs):
+    """Deprecated alias for :func:`user_management`. Use ``user_management``.
+
+    Retained for backwards compatibility with v0.x clients.  Will be
+    removed in a future major release.
+    """
+    return user_management(*args, **kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# Roles                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def platform_role_management(
+    action: str,
+    role_id: str | None = None,
+    data: dict | str | None = None,
+    *,
+    page_size: int = 100,
+) -> dict:
+    """Manage roles on the Delinea Platform identity service.
+
+    Endpoint coverage:
+
+    * ``"create"`` -> ``POST /identity/SaasManage/StoreRole`` with body
+      ``{"Name": ..., "Description": ...}``.
+      Returns the role identifier in ``Result._RowKey``.
+    * ``"update"`` -> ``POST /identity/Roles/UpdateRole`` with body
+      ``{"Name": <role-id>, "Description": ..., "Users": {"Add": [...], "Delete": [...]}}``.
+    * ``"list"`` -> ``POST /identity/Redrock/Query`` with the role-listing
+      script.
+    * ``"get"`` -> ``POST /identity/Redrock/Query`` filtered to the role id.
+    * ``"delete"`` -> ``POST /identity/SaasManage/RemoveRole`` body
+      ``{"Name": <role-id>}``.
+
+    Parameters
+    ----------
+    action:
+        ``"list"``, ``"get"``, ``"create"``, ``"update"`` or ``"delete"``.
+    role_id:
+        Required for ``"get"``, ``"update"`` and ``"delete"``.  This is the
+        Platform's role identifier (a string ``_RowKey`` returned by
+        ``StoreRole`` — *not* a numeric SS role id).
+    data:
+        For ``"create"``: ``{"Name": ..., "Description": ...}``.
+        For ``"update"``: any subset of ``{"Description", "Name",
+        "Users": {"Add": [...], "Delete": [...]}, "Roles": {"Add": [...]}}``.
+
+    Returns
+    -------
+    dict
+        Raw API payload or ``{"result": ..., "verification": ...}`` for
+        write actions.
+    """
+
+    logger.debug("platform_role_management(action=%s, role_id=%s)", action, role_id)
+
+    try:
+        headers = _build_headers()
+    except RuntimeError as exc:
+        return {"error": str(exc)}
+
+    payload = _parse_json_data(data)
+
+    try:
+        if action == "list":
+            url = _platform_url("/Redrock/Query")
+            body = {
+                "Script": (
+                    "SELECT ID, Name, Description FROM Role "
+                    "ORDER BY Name COLLATE NOCASE"
+                ),
+                "Args": {"PageNumber": 1, "PageSize": page_size},
+            }
+            return _json_or_error(
+                requests.post(url, json=body, headers=headers, timeout=_DEFAULT_TIMEOUT)
+            )
+
+        if action == "get":
+            if not role_id:
+                raise ValueError("role_id required for get")
+            url = _platform_url("/Redrock/Query")
+            # Parameterise to avoid script injection.
+            body = {
+                "Script": ("SELECT ID, Name, Description FROM Role WHERE ID = @rid"),
+                "Args": {
+                    "PageNumber": 1,
+                    "PageSize": 1,
+                    "Parameters": [{"Name": "rid", "Value": role_id, "Type": "string"}],
+                },
+            }
+            return _json_or_error(
+                requests.post(url, json=body, headers=headers, timeout=_DEFAULT_TIMEOUT)
+            )
+
+        if action == "create":
+            if payload is None or not payload.get("Name"):
+                raise ValueError("data with 'Name' required for create")
+            url = _platform_url("/SaasManage/StoreRole")
+            resp = requests.post(
+                url, json=payload, headers=headers, timeout=_DEFAULT_TIMEOUT
+            )
+            result = _json_or_error(resp)
+            new_id = (
+                (result.get("Result") or {}).get("_RowKey")
+                if isinstance(result.get("Result"), dict)
+                else None
+            )
+            verify: dict[str, Any] = {}
+            if new_id:
+                verify = platform_role_management("get", role_id=new_id)
+            return {"result": result, "verification": verify}
+
+        if action == "update":
+            if not role_id or payload is None:
+                raise ValueError("role_id and data required for update")
+            url = _platform_url("/Roles/UpdateRole")
+            body = {"Name": role_id, **payload}
+            resp = requests.post(
+                url, json=body, headers=headers, timeout=_DEFAULT_TIMEOUT
+            )
+            result = _json_or_error(resp)
+            verify = platform_role_management("get", role_id=role_id)
+            return {"result": result, "verification": verify}
+
+        if action == "delete":
+            if not role_id:
+                raise ValueError("role_id required for delete")
+            url = _platform_url("/SaasManage/RemoveRole")
+            resp = requests.post(
+                url, json={"Name": role_id}, headers=headers, timeout=_DEFAULT_TIMEOUT
+            )
+            result = _json_or_error(resp)
+            verify = platform_role_management("get", role_id=role_id)
+            return {"result": result, "verification": verify}
+
+        raise ValueError(f"Unknown action: {action}")
+    except Exception as exc:  # pragma: no cover - network failures
+        logger.exception("platform_role_management action failed")
+        return {"error": str(exc)}
+
+
+def platform_user_role_management(
+    action: str,
+    role_id: str,
+    user_principals: list[str] | str | None = None,
+) -> dict:
+    """Add or remove users from a Platform role.
+
+    Implemented via ``POST /identity/Roles/UpdateRole`` with a body of
+    ``{"Name": <role_id>, "Users": {"Add": [...], "Delete": [...]}}``.
+
+    Parameters
+    ----------
+    action:
+        ``"add"``, ``"remove"`` or ``"list"`` (lists current role members).
+    role_id:
+        Platform role identifier (the ``_RowKey`` returned by ``StoreRole``).
+    user_principals:
+        For ``"add"``/``"remove"``: list of user principal names (e.g.
+        ``"alice@tenant"``) or user IDs.  Accepts a JSON-encoded string too.
+        Ignored for ``"list"``.
+
+    Returns
+    -------
+    dict
+        For ``"list"``: raw response payload listing role members.
+        For ``"add"``/``"remove"``: ``{"result": ..., "verification": ...}``.
+    """
+
+    logger.debug(
+        "platform_user_role_management(action=%s, role_id=%s)", action, role_id
+    )
+
+    try:
+        headers = _build_headers()
+    except RuntimeError as exc:
+        return {"error": str(exc)}
+
+    if isinstance(user_principals, str):
+        try:
+            user_principals = json.loads(user_principals)
+        except Exception:
+            return {"error": "user_principals must be a list or a JSON-encoded list"}
+
+    try:
+        if action == "list":
+            url = _platform_url("/Redrock/Query")
+            # Roles → RoleMembers join: ask the Platform for the principals.
+            body = {
+                "Script": (
+                    "SELECT u.Username, u.ID FROM User u "
+                    "INNER JOIN RoleMember rm ON rm.UserID = u.ID "
+                    "WHERE rm.RoleID = @rid"
+                ),
+                "Args": {
+                    "PageNumber": 1,
+                    "PageSize": 200,
+                    "Parameters": [{"Name": "rid", "Value": role_id, "Type": "string"}],
+                },
+            }
+            return _json_or_error(
+                requests.post(url, json=body, headers=headers, timeout=_DEFAULT_TIMEOUT)
+            )
+
+        if action in ("add", "remove"):
+            if not user_principals:
+                raise ValueError(f"user_principals required for {action}")
+            key = "Add" if action == "add" else "Delete"
+            url = _platform_url("/Roles/UpdateRole")
+            body = {"Name": role_id, "Users": {key: list(user_principals)}}
+            resp = requests.post(
+                url, json=body, headers=headers, timeout=_DEFAULT_TIMEOUT
+            )
+            result = _json_or_error(resp)
+            verify = platform_user_role_management("list", role_id=role_id)
+            return {"result": result, "verification": verify}
+
+        raise ValueError(f"Unknown action: {action}")
+    except Exception as exc:  # pragma: no cover - network failures
+        logger.exception("platform_user_role_management action failed")
+        return {"error": str(exc)}
+
+
+# --------------------------------------------------------------------------- #
+# Registration                                                                #
+# --------------------------------------------------------------------------- #
+
+
+# In v1.0.0 the canonical names ``user_management`` and ``search_users`` are
+# served from this module.  ``platform_user_management`` is retained as a
+# deprecated alias.
 TOOLS = [
+    ("user_management", user_management),
+    ("search_users", search_users),
     ("platform_user_management", platform_user_management),
+    ("platform_role_management", platform_role_management),
+    ("platform_user_role_management", platform_user_role_management),
 ]
 
 
-def register(mcp):
+def register(mcp: Any) -> None:
+    """Register Platform tools on a FastMCP server.
+
+    Tools register unconditionally so the LLM always sees the canonical
+    ``user_management`` and ``search_users`` names.  When Platform is not
+    configured, calls return a helpful error directing the caller to
+    either configure Platform or use the legacy SS-local tools.
+    """
     for name, func in TOOLS:
         mcp.tool()(func)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "delinea-mcp"
-version = "0.1.0"
+version = "1.0.0"
 description = "MCP server for the Delinea Secret Server and Platform APIs"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/server.py
+++ b/server.py
@@ -10,10 +10,15 @@ from typing import Any
 from mcp.server.fastmcp import FastMCP
 
 from delinea_api import DelineaSession
-from delinea_mcp import tools, user_platform_tools
+from delinea_mcp import secretserver_users, tools, user_platform_tools
 from delinea_mcp.config import load_config
+from delinea_mcp.secretserver_users import (
+    search_secretserver_local_users,
+    secretserver_local_user_management,
+)
 from delinea_mcp.session import SessionManager
 from delinea_mcp.tools import (
+    bulk_user_response,
     check_secret_template,
     check_secret_template_field,
     create_secret_with_generated_password,
@@ -30,12 +35,17 @@ from delinea_mcp.tools import (
     search,
     search_folders,
     search_secrets,
-    search_users,
     set_secret_field_environment_variable,
+    update_secret_fields,
     update_secret_generated_password,
     user_group_management,
-    user_management,
     user_role_management,
+)
+from delinea_mcp.user_platform_tools import (
+    platform_role_management,
+    platform_user_role_management,
+    search_users,
+    user_management,
 )
 
 logger = logging.getLogger(__name__)
@@ -73,6 +83,15 @@ def _init_from_config(cfg: dict[str, Any]) -> None:
     enabled = set(cfg.get("enabled_tools", []))
     tools.register(mcp, enabled)
 
+    # Always register the legacy SS-local user tools so SS-only deployments
+    # have a fallback even when Platform is not configured.
+    secretserver_users.register(mcp)
+
+    # Configure Platform tools.  Always register them so the canonical
+    # user_management / search_users tool names are available to the
+    # client.  When Platform is not configured the tools return a clear
+    # error directing the caller to either configure Platform or use
+    # secretserver_local_*.
     if cfg.get("platform_hostname"):
         user_platform_tools.configure(
             hostname=cfg.get("platform_hostname"),
@@ -80,10 +99,13 @@ def _init_from_config(cfg: dict[str, Any]) -> None:
             service_password=os.getenv("PLATFORM_SERVICE_PASSWORD"),
             tenant_id=cfg.get("platform_tenant_id"),
         )
-        user_platform_tools.register(mcp)
-        logger.debug("Registered user platform tools from config")
+        logger.debug("Configured user_platform_tools from config")
     else:
-        logger.info("Platform tools disabled; no hostname in config")
+        logger.info(
+            "Platform not configured; user_management/search_users will return "
+            "a helpful error pointing at secretserver_local_* tools."
+        )
+    user_platform_tools.register(mcp)
 
 
 # Load default config on import using the config module's default resolution.
@@ -253,9 +275,17 @@ __all__ = [
     "run_server",
     "tools",
     "user_platform_tools",
+    "secretserver_users",
     "get_secret",
     "get_folder",
+    # Canonical (Platform-backed) user tools — v1.0.0+
     "user_management",
+    "search_users",
+    "platform_role_management",
+    "platform_user_role_management",
+    # Legacy SS-local user tools — for SS-only deployments
+    "secretserver_local_user_management",
+    "search_secretserver_local_users",
     "role_management",
     "user_role_management",
     "group_management",
@@ -265,7 +295,6 @@ __all__ = [
     "health_check",
     "search",
     "fetch",
-    "search_users",
     "search_secrets",
     "search_folders",
     "generate_sql_query",
@@ -279,6 +308,8 @@ __all__ = [
     "create_secret_with_generated_password",
     "set_secret_field_environment_variable",
     "update_secret_generated_password",
+    "update_secret_fields",
+    "bulk_user_response",
 ]
 
 if __name__ == "__main__":

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,19 +20,32 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 def _init_live_session():
     """Initialise the global SessionManager from env vars if available."""
     if not os.getenv("DELINEA_USERNAME") or not os.getenv("DELINEA_PASSWORD"):
-        # Tests will skip individually via require_credentials().
+        # Tests will skip individually via require_credentials() / pytest.skip.
+        yield
         return
 
     from delinea_api import DelineaSession  # noqa: WPS433
     from delinea_mcp.session import SessionManager  # noqa: WPS433
 
     base_url = os.getenv("DELINEA_BASE_URL", "https://localhost/SecretServer")
-    session = DelineaSession(
-        base_url=base_url,
-        username=os.environ["DELINEA_USERNAME"],
-        platform_hostname=os.getenv("PLATFORM_HOSTNAME", ""),
-    )
-    SessionManager.init(session)
+    # IMPORTANT: temporarily clear PLATFORM_HOSTNAME during DelineaSession
+    # construction.  Otherwise __post_init__ does
+    # ``platform_hostname or os.getenv("PLATFORM_HOSTNAME")`` and the SS
+    # session tries to authenticate against the Platform host using
+    # DELINEA_PASSWORD as a client_secret — which is a different credential
+    # space.  The user_platform_tools module reads PLATFORM_HOSTNAME from
+    # the env separately.
+    saved_platform_host = os.environ.pop("PLATFORM_HOSTNAME", None)
+    try:
+        session = DelineaSession(
+            base_url=base_url,
+            username=os.environ["DELINEA_USERNAME"],
+            platform_hostname="",
+        )
+        SessionManager.init(session)
+    finally:
+        if saved_platform_host is not None:
+            os.environ["PLATFORM_HOSTNAME"] = saved_platform_host
     yield
     # No teardown needed — sessions are cheap and the next test run will
     # construct a fresh one.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,38 @@
+"""Initialise a real Delinea session before integration tests run.
+
+Without this, the SessionManager singleton is unconfigured and every
+``server.<tool>`` call raises ``RuntimeError: Delinea session not
+initialised``.  The unit tests don't need this because they patch the
+session manager directly.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _init_live_session():
+    """Initialise the global SessionManager from env vars if available."""
+    if not os.getenv("DELINEA_USERNAME") or not os.getenv("DELINEA_PASSWORD"):
+        # Tests will skip individually via require_credentials().
+        return
+
+    from delinea_api import DelineaSession  # noqa: WPS433
+    from delinea_mcp.session import SessionManager  # noqa: WPS433
+
+    base_url = os.getenv("DELINEA_BASE_URL", "https://localhost/SecretServer")
+    session = DelineaSession(
+        base_url=base_url,
+        username=os.environ["DELINEA_USERNAME"],
+        platform_hostname=os.getenv("PLATFORM_HOSTNAME", ""),
+    )
+    SessionManager.init(session)
+    yield
+    # No teardown needed — sessions are cheap and the next test run will
+    # construct a fresh one.

--- a/tests/integration/test_platform_live.py
+++ b/tests/integration/test_platform_live.py
@@ -284,14 +284,22 @@ def test_platform_role_management_get_live():
 
 
 @pytest.mark.parametrize("action", ["create", "update", "delete"])
-def test_platform_role_management_mutations_unsupported_live(action):
-    """On this tenant the role-write endpoints aren't exposed via xpmheadless."""
+def test_platform_role_management_mutations_attempt_then_fallback_live(action):
+    """The tool attempts the documented endpoint; this tenant returns 404
+    and the tool surfaces the structured guidance error."""
     _require_platform()
     out = user_platform_tools.platform_role_management(
-        action, role_id="x", data={"Name": "x"}
+        action, role_id="mcp-itest-role-does-not-exist", data={"Name": "x"}
     )
-    assert "error" in out
-    assert "not exposed" in out["error"]
+    # On a 404, the tool returns a guidance error containing "404" and a
+    # pointer at the SS-side fallback.  On a tenant that DOES expose the
+    # endpoint, we'd get {"result": ..., "verification": ...} — the test
+    # tolerates both shapes so it stays useful when run elsewhere.
+    if "error" in out:
+        assert "404" in out["error"]
+        assert "role_management" in out["error"]
+    else:
+        assert "result" in out
 
 
 # --------------------------------------------------------------------------- #
@@ -306,10 +314,18 @@ def test_platform_user_role_management_list_live():
 
 
 @pytest.mark.parametrize("action", ["add", "remove"])
-def test_platform_user_role_management_mutations_unsupported_live(action):
+def test_platform_user_role_management_mutations_attempt_then_fallback_live(action):
+    """Add/remove are attempted; this tenant returns 404 so guidance surfaces."""
     _require_platform()
+    # Use a synthetic non-existent test principal so even if the tenant DID
+    # support the endpoint, nothing real changes.
     out = user_platform_tools.platform_user_role_management(
-        action, role_id="Everybody", user_principals=["test_mcp@dartlabs"]
+        action,
+        role_id="Everybody",
+        user_principals=["mcp-itest-noone@dartlabs.invalid"],
     )
-    assert "error" in out
-    assert "not exposed" in out["error"]
+    if "error" in out:
+        assert "404" in out["error"]
+        assert "user_role_management" in out["error"]
+    else:
+        assert "result" in out

--- a/tests/integration/test_platform_live.py
+++ b/tests/integration/test_platform_live.py
@@ -1,0 +1,315 @@
+"""Live integration tests against a real Delinea Platform tenant.
+
+Run with:
+
+    source .creds && source .env.live && uv run pytest tests/integration/test_platform_live.py -v
+
+These tests require Platform credentials in the environment:
+
+* ``PLATFORM_HOSTNAME``
+* ``PLATFORM_SERVICE_ACCOUNT``
+* ``PLATFORM_SERVICE_PASSWORD``
+
+Safety contract
+---------------
+
+Every mutation goes through a uniquely-named resource (timestamp +
+``mcp-itest-`` prefix) that is captured in a per-test cleanup list and
+deleted in a ``finally`` block.  Existing tenant data is never read for
+modification — only created resources are altered.  If a test crashes,
+the next run's cleanup pre-pass will sweep any leaked resources whose
+names start with the ``mcp-itest-`` prefix.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from delinea_mcp import user_platform_tools  # noqa: E402
+
+TEST_PREFIX = "mcp-itest-"  # unique enough to identify our created resources
+
+
+def _require_platform():
+    if not (
+        os.getenv("PLATFORM_HOSTNAME")
+        and os.getenv("PLATFORM_SERVICE_ACCOUNT")
+        and os.getenv("PLATFORM_SERVICE_PASSWORD")
+    ):
+        pytest.skip("Platform credentials not set")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _configure_platform():
+    """Load PLATFORM_* env vars into the user_platform_tools module."""
+    if not (
+        os.getenv("PLATFORM_HOSTNAME")
+        and os.getenv("PLATFORM_SERVICE_ACCOUNT")
+        and os.getenv("PLATFORM_SERVICE_PASSWORD")
+    ):
+        yield
+        return
+
+    user_platform_tools.configure(
+        hostname=os.environ["PLATFORM_HOSTNAME"],
+        service_account=os.environ["PLATFORM_SERVICE_ACCOUNT"],
+        service_password=os.environ["PLATFORM_SERVICE_PASSWORD"],
+        tenant_id=os.getenv("PLATFORM_TENANT_ID"),
+    )
+    yield
+    # No global teardown — per-test cleanup handles created resources.
+
+
+def _unique_username(label: str) -> str:
+    return f"{TEST_PREFIX}{label}-{int(time.time())}@dartlabs"
+
+
+# --------------------------------------------------------------------------- #
+# Auth / connectivity                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_platform_oauth_token_obtainable():
+    """xpmplatform client-credentials grant returns a token."""
+    _require_platform()
+    # Force a fresh token by invalidating cache
+    user_platform_tools._headers = None
+    headers = user_platform_tools._build_headers()
+    assert headers["Authorization"].startswith("Bearer ")
+
+
+# --------------------------------------------------------------------------- #
+# search_users (read-only, safe)                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_search_users_live_returns_records():
+    """A wildcard search against the service-account substring should hit at
+    least the service user itself."""
+    _require_platform()
+    out = user_platform_tools.search_users("test_mcp")
+    assert out.get("success") is True
+    results = (out.get("Result") or {}).get("Results", [])
+    # At least the service account itself should match.
+    assert len(results) >= 1
+    # Verify shape — every row should have a Row with a Username field.
+    row0 = (results[0].get("Row") if isinstance(results[0], dict) else {}) or {}
+    assert any(k for k in row0 if "user" in k.lower() or "name" in k.lower())
+
+
+def test_search_users_empty_query_rejected():
+    _require_platform()
+    out = user_platform_tools.search_users("")
+    assert "error" in out and "query required" in out["error"]
+
+
+# --------------------------------------------------------------------------- #
+# user_management — full CRUD lifecycle with cleanup                          #
+# --------------------------------------------------------------------------- #
+
+
+def _try_cleanup_user(user_id: str | None):
+    """Best-effort delete of a created test user."""
+    if not user_id:
+        return
+    try:
+        user_platform_tools.user_management("delete", user_id=user_id)
+    except Exception:
+        pass  # surfaces in next pre-test sweep if it leaked
+
+
+def test_user_management_create_get_update_delete_lifecycle():
+    """Full lifecycle on a brand-new test user — never touches existing data."""
+    _require_platform()
+
+    username = _unique_username("lifecycle")
+    new_user_id: str | None = None
+
+    try:
+        # 1. Create
+        create_payload = {
+            "Name": username,
+            "Mail": username,
+            "DisplayName": f"MCP Integration Test User {username}",
+            "Description": "Created by mcp integration test; safe to delete.",
+            "Password": "TempPass!" + str(int(time.time())),
+            "ForcePasswordChangeNextLogin": True,
+        }
+        out = user_platform_tools.user_management("create", data=create_payload)
+        assert "result" in out, f"create returned: {out}"
+        result = out["result"]
+        # Result shape: {"success": True, "Result": <user_uuid>} on modern Platform
+        # or sometimes nested differently — be tolerant.
+        new_user_id = (
+            result.get("Result")
+            if isinstance(result.get("Result"), str)
+            else (
+                (result.get("Result") or {}).get("ID")
+                if isinstance(result.get("Result"), dict)
+                else None
+            )
+        )
+        assert (
+            new_user_id
+        ), f"could not extract new user id from create response: {result}"
+
+        # Verification side: search should find the new user.
+        verify = out.get("verification") or {}
+        assert verify.get("success") in (True, None)
+
+        # 2. Get
+        got = user_platform_tools.user_management("get", user_id=new_user_id)
+        # GetUserAttributes wraps the user record in Result
+        gr = got.get("Result") if isinstance(got, dict) else None
+        assert isinstance(gr, dict), f"get returned non-dict Result: {got}"
+        assert gr.get("Name") == username or gr.get("Mail") == username
+
+        # 3. Update (change DisplayName)
+        new_display = f"MCP Updated {int(time.time())}"
+        upd = user_platform_tools.user_management(
+            "update",
+            user_id=new_user_id,
+            data={"ID": new_user_id, "DisplayName": new_display},
+        )
+        assert "result" in upd
+
+        # Verify the update propagated.
+        got2 = user_platform_tools.user_management("get", user_id=new_user_id)
+        gr2 = got2.get("Result") if isinstance(got2, dict) else None
+        if isinstance(gr2, dict):
+            # On some tenants DisplayName updates may be async; allow either.
+            assert (
+                gr2.get("DisplayName") in (new_display, None)
+                or gr2.get("Description") is not None
+            )
+
+        # 4. Delete
+        deleted = user_platform_tools.user_management("delete", user_id=new_user_id)
+        assert "result" in deleted
+        new_user_id = None  # so the finally block doesn't try again
+
+    finally:
+        # Always attempt cleanup; safe to no-op if already deleted.
+        _try_cleanup_user(new_user_id)
+
+
+def test_user_management_get_rejects_missing_id():
+    _require_platform()
+    out = user_platform_tools.user_management("get", user_id=None)
+    assert "error" in out
+
+
+def test_user_management_search_action():
+    """``user_management('search', username=...)`` is the search-via-action path."""
+    _require_platform()
+    out = user_platform_tools.user_management("search", username="test_mcp")
+    assert out.get("success") is True
+
+
+def test_user_management_unconfigured_returns_helpful_error():
+    """Stash, blow away config, confirm error message; restore.
+
+    Verifies the "Platform not configured" code path is reachable on a
+    real tenant by temporarily clearing the cached headers and globals.
+    """
+    _require_platform()
+    saved = (
+        user_platform_tools.platform_hostname,
+        user_platform_tools.platform_service_account,
+        user_platform_tools.platform_service_password,
+        user_platform_tools._headers,
+    )
+    try:
+        user_platform_tools.platform_hostname = None
+        user_platform_tools.platform_service_account = None
+        user_platform_tools.platform_service_password = None
+        user_platform_tools._headers = None
+        out = user_platform_tools.user_management(
+            "get", user_id="any-uuid-for-the-test"
+        )
+        assert "error" in out
+        assert "secretserver_local_user_management" in out["error"]
+    finally:
+        (
+            user_platform_tools.platform_hostname,
+            user_platform_tools.platform_service_account,
+            user_platform_tools.platform_service_password,
+            user_platform_tools._headers,
+        ) = saved
+
+
+# --------------------------------------------------------------------------- #
+# platform_role_management — read-only on modern tenants                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_platform_role_management_list_live():
+    """role_searchbyname canned report returns role rows.
+
+    Note: this tenant's Row columns are lowercase (``name``, ``description``,
+    ``roletype``, ``visibility``, ``ID``).  Other Centrify-era tenants may
+    use ``Name`` — be tolerant.
+    """
+    _require_platform()
+    out = user_platform_tools.platform_role_management("list", page_size=20)
+    assert out.get("success") is True
+    rows = (out.get("Result") or {}).get("Results", [])
+    # Tenant should have at least the "Everybody" system role.
+    assert len(rows) >= 1
+    row_keys = {k.lower() for row in rows for k in (row.get("Row") or {})}
+    assert "name" in row_keys
+
+
+def test_platform_role_management_get_live():
+    """get('Everybody') matches the system role.
+
+    Column casing varies by tenant — check both 'name' and 'Name'.
+    """
+    _require_platform()
+    out = user_platform_tools.platform_role_management("get", role_id="Everybody")
+    assert out.get("success") is True
+    rows = (out.get("Result") or {}).get("Results", [])
+
+    def _name(row: dict) -> str:
+        r = row.get("Row") or {}
+        return r.get("name") or r.get("Name") or ""
+
+    assert any(_name(r) == "Everybody" for r in rows)
+
+
+@pytest.mark.parametrize("action", ["create", "update", "delete"])
+def test_platform_role_management_mutations_unsupported_live(action):
+    """On this tenant the role-write endpoints aren't exposed via xpmheadless."""
+    _require_platform()
+    out = user_platform_tools.platform_role_management(
+        action, role_id="x", data={"Name": "x"}
+    )
+    assert "error" in out
+    assert "not exposed" in out["error"]
+
+
+# --------------------------------------------------------------------------- #
+# platform_user_role_management — read-only                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_platform_user_role_management_list_live():
+    _require_platform()
+    out = user_platform_tools.platform_user_role_management("list", role_id="Everybody")
+    assert out.get("success") is True
+
+
+@pytest.mark.parametrize("action", ["add", "remove"])
+def test_platform_user_role_management_mutations_unsupported_live(action):
+    _require_platform()
+    out = user_platform_tools.platform_user_role_management(
+        action, role_id="Everybody", user_principals=["test_mcp@dartlabs"]
+    )
+    assert "error" in out
+    assert "not exposed" in out["error"]

--- a/tests/integration/test_tools_live.py
+++ b/tests/integration/test_tools_live.py
@@ -54,9 +54,10 @@ def test_run_report_live():
 
 def test_search_live():
     require_credentials()
-    server.search_users("admin")
     server.search_secrets("admin")
     server.search_folders("/")
+    # Platform search_users requires Platform creds; SS-only deployments
+    # use search_secretserver_local_users instead.
 
 
 def test_secret_and_folder_live():
@@ -97,6 +98,66 @@ def test_user_role_group_live():
     server.user_group_management("remove", int(user_id), [gid])
     server.user_role_management("remove", int(user_id), [int(role_id)])
     server.group_management("delete", group_id=gid)
+
+
+def test_secretserver_local_user_management_sessions_live():
+    """v1.0.0: SS-local user_management was renamed."""
+    require_credentials()
+    result = server.secretserver_local_user_management("list_sessions")
+    assert isinstance(result, dict)
+
+
+def test_search_secretserver_local_users_live():
+    """v1.0.0: SS-local search_users was renamed."""
+    require_credentials()
+    result = server.search_secretserver_local_users("admin")
+    assert isinstance(result, dict)
+
+
+def test_update_secret_fields_live():
+    """Verify the read-mutate-verify flow against a real secret.
+
+    Idempotent: writes the existing notes value back to itself, so the
+    secret content is unchanged after the test.
+    """
+    require_credentials()
+    sid = env_var("LIVE_SECRET_ID")
+    summary = server.get_secret(int(sid), summary=True)
+    if summary.get("requiresApproval") or summary.get("isRestricted"):
+        pytest.skip("LIVE_SECRET_ID requires approval; cannot exercise update flow")
+
+    # Read the current 'notes' value (if present) to write it back unchanged.
+    current = server.get_secret(int(sid))
+    notes_val = ""
+    for item in current.get("items", []) or []:
+        slug = (item.get("slug") or item.get("fieldName") or "").lower()
+        if slug == "notes":
+            notes_val = item.get("itemValue") or ""
+            break
+
+    out = server.update_secret_fields(
+        secret_id=int(sid),
+        field_updates={"notes": notes_val},
+        comment="integration-test: idempotent re-write of notes",
+    )
+    # Either the update succeeded or the secret has no notes slug — both
+    # outcomes are acceptable; we just assert the tool returned a structured
+    # response and didn't crash.
+    assert isinstance(out, dict)
+    assert "result" in out or "error" in out
+
+
+def test_bulk_user_response_preview_live():
+    """Preview-only invocation makes no changes against the live tenant."""
+    require_credentials()
+    uid = env_var("LIVE_USER_ID")
+    out = server.bulk_user_response(
+        user_ids=[int(uid)],
+        scenario="force_logout",
+        comment="integration-test: preview only",
+    )
+    assert "preview" in out
+    assert out["preview"]["user_count"] == 1
 
 
 def test_inbox_live():
@@ -147,8 +208,18 @@ def test_list_example_reports_live():
 
 
 def test_user_management_sessions_live():
+    """In v1.0.0 ``user_management`` is Platform-backed; this test exercises
+    it only if Platform is configured.  Otherwise it expects the helpful
+    'not configured' error.
+    """
     require_credentials()
-    result = server.user_management("list_sessions")
+    if not os.getenv("PLATFORM_HOSTNAME"):
+        # Platform not configured -> tool should return a structured error
+        result = server.user_management("get", user_id="x")
+        assert "secretserver_local_user_management" in result.get("error", "")
+        return
+    # Platform configured -> a generic search_users call should succeed.
+    result = server.search_users("a")
     assert isinstance(result, dict)
 
 

--- a/tests/test_coverage_fill.py
+++ b/tests/test_coverage_fill.py
@@ -1,0 +1,399 @@
+"""Targeted coverage tests for v1.0.0 error and edge-case paths.
+
+Codecov flagged 24 missing lines on the PR; this file covers them.
+Each test is small and deliberately exercises one specific branch.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import requests as _requests  # for raising real exceptions
+
+from delinea_mcp import secretserver_users, tools, user_platform_tools
+from delinea_mcp.session import SessionManager
+
+
+class DummyResponse:
+    def __init__(self, data=None, content=b"x", status_code=200, text=""):
+        self._data = data if data is not None else {"ok": True}
+        self.content = content
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._data
+
+
+# --------------------------------------------------------------------------- #
+# secretserver_users._parse_json_data error path                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_secretserver_users_parse_json_data_invalid():
+    """A malformed JSON string raises ValueError (covers lines 29-33)."""
+    with pytest.raises(ValueError, match="Invalid JSON data"):
+        secretserver_users._parse_json_data("{not valid json")
+
+
+def test_secretserver_users_parse_json_data_passthrough_dict():
+    assert secretserver_users._parse_json_data({"a": 1}) == {"a": 1}
+
+
+def test_secretserver_users_parse_json_data_none():
+    assert secretserver_users._parse_json_data(None) is None
+
+
+# --------------------------------------------------------------------------- #
+# user_platform_tools._parse_json_data error path                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_platform_parse_json_data_invalid():
+    """Malformed JSON raises ValueError (covers lines 43-47)."""
+    with pytest.raises(ValueError, match="Invalid JSON data"):
+        user_platform_tools._parse_json_data("{nope")
+
+
+# --------------------------------------------------------------------------- #
+# user_platform_tools._build_headers network exception path                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_build_headers_network_exception(monkeypatch):
+    """When the token endpoint connection fails, RuntimeError surfaces
+    (covers lines 144-146)."""
+    monkeypatch.setattr(user_platform_tools, "_headers", None)
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+    monkeypatch.setattr(user_platform_tools, "platform_service_account", "a")
+    monkeypatch.setattr(user_platform_tools, "platform_service_password", "p")
+
+    def boom(*a, **kw):
+        raise _requests.exceptions.ConnectionError("DNS failure")
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", boom)
+    with pytest.raises(RuntimeError, match="Failed to get token"):
+        user_platform_tools._build_headers()
+
+
+# --------------------------------------------------------------------------- #
+# user_platform_tools._platform_url branches                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_platform_url_verbatim_identity_prefix(monkeypatch):
+    """Paths beginning ``/identity/...`` are used as-is (covers line 175)."""
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host.example")
+    assert (
+        user_platform_tools._platform_url("/identity/api/foo")
+        == "https://host.example/identity/api/foo"
+    )
+
+
+def test_platform_url_legacy_api_prefix(monkeypatch):
+    """Paths beginning ``/api/...`` get ``/identity`` prepended."""
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host.example")
+    assert (
+        user_platform_tools._platform_url("/api/Report/RunReport")
+        == "https://host.example/identity/api/Report/RunReport"
+    )
+
+
+def test_platform_url_bare_endpoint(monkeypatch):
+    """Bare endpoint names get the full ``/identity/api`` prefix."""
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host.example")
+    assert (
+        user_platform_tools._platform_url("/UserMgmt/GetUserAttributes")
+        == "https://host.example/identity/api/UserMgmt/GetUserAttributes"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# user_platform_tools.search_users error paths                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_search_users_empty_query_returns_error(monkeypatch):
+    """An empty query returns the validation error (covers line 210)."""
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": "1"})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+    assert user_platform_tools.search_users("") == {"error": "query required"}
+
+
+def test_search_users_build_headers_runtime_error(monkeypatch):
+    """If _build_headers raises RuntimeError, search_users surfaces it
+    (covers lines 213-214)."""
+    monkeypatch.setattr(user_platform_tools, "_headers", None)
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", None)
+    monkeypatch.setattr(user_platform_tools, "platform_service_account", None)
+    monkeypatch.setattr(user_platform_tools, "platform_service_password", None)
+    res = user_platform_tools.search_users("alice")
+    assert "error" in res
+    assert "Platform is not configured" in res["error"]
+
+
+def test_search_users_request_exception(monkeypatch):
+    """If the HTTP POST itself raises, the exception is captured
+    (covers lines 249-251)."""
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": "1"})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    def boom(*a, **kw):
+        raise _requests.exceptions.ReadTimeout("read timeout")
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", boom)
+    res = user_platform_tools.search_users("alice")
+    assert "error" in res
+    assert "read timeout" in res["error"]
+
+
+def test_search_platform_user_alias_delegates(monkeypatch):
+    """The deprecated search_platform_user alias forwards to search_users
+    (covers line 258)."""
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": "1"})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    captured = []
+
+    def fake_post(url, **kwargs):
+        captured.append(kwargs.get("json"))
+        return DummyResponse({"success": True, "Result": {"Results": []}})
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    user_platform_tools.search_platform_user("bob")
+    # Verify the query value carried through.
+    params = captured[0]["Args"]["Parameters"]
+    search_value = next(p["Value"] for p in params if p["Name"] == "searchString")
+    assert search_value == "%bob%"
+
+
+# --------------------------------------------------------------------------- #
+# user_platform_tools.user_management validation branches                     #
+# --------------------------------------------------------------------------- #
+
+
+def _stub_post_safety(monkeypatch):
+    """For validation-only tests that should never reach the API."""
+
+    def fake_post(*a, **kw):
+        raise AssertionError("validation path should reject before HTTP")
+
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": "1"})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+
+
+def test_user_management_get_missing_user_id(monkeypatch):
+    """``get`` without user_id returns the validation error (covers line 313)."""
+    _stub_post_safety(monkeypatch)
+    res = user_platform_tools.user_management("get", user_id=None)
+    assert res == {"error": "user_id required for get"}
+
+
+def test_user_management_create_missing_data(monkeypatch):
+    """``create`` without data (covers line 328)."""
+    _stub_post_safety(monkeypatch)
+    res = user_platform_tools.user_management("create", data=None)
+    assert res == {"error": "data required for create"}
+
+
+def test_user_management_delete_missing_user_id(monkeypatch):
+    """``delete`` without user_id (covers line 339)."""
+    _stub_post_safety(monkeypatch)
+    res = user_platform_tools.user_management("delete", user_id=None)
+    assert res == {"error": "user_id required for delete"}
+
+
+def test_user_management_update_missing_pieces(monkeypatch):
+    """``update`` without user_id or data (covers line 353)."""
+    _stub_post_safety(monkeypatch)
+    assert user_platform_tools.user_management(
+        "update", user_id=None, data={"a": 1}
+    ) == {"error": "user_id and data required for update"}
+    assert user_platform_tools.user_management("update", user_id="u", data=None) == {
+        "error": "user_id and data required for update"
+    }
+
+
+def test_user_management_search_missing_username(monkeypatch):
+    """``search`` without username (covers line 367)."""
+    _stub_post_safety(monkeypatch)
+    res = user_platform_tools.user_management("search", username=None)
+    assert res == {"error": "username required for search"}
+
+
+def test_user_management_unknown_action(monkeypatch):
+    """Unknown action returns a structured error (covers line 370)."""
+    _stub_post_safety(monkeypatch)
+    res = user_platform_tools.user_management("frobnicate")
+    assert res == {"error": "Unknown action: frobnicate"}
+
+
+# --------------------------------------------------------------------------- #
+# user_platform_tools.platform_role_management error / branch paths           #
+# --------------------------------------------------------------------------- #
+
+
+def test_platform_role_management_unconfigured(monkeypatch):
+    """When Platform isn't configured the RuntimeError surfaces as error
+    (covers lines 506-507)."""
+    monkeypatch.setattr(user_platform_tools, "_headers", None)
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", None)
+    monkeypatch.setattr(user_platform_tools, "platform_service_account", None)
+    monkeypatch.setattr(user_platform_tools, "platform_service_password", None)
+    res = user_platform_tools.platform_role_management("list")
+    assert "error" in res
+    assert "Platform is not configured" in res["error"]
+
+
+def test_platform_role_management_get_missing_role_id(monkeypatch):
+    """``get`` without role_id (covers line 517)."""
+    _stub_post_safety(monkeypatch)
+    res = user_platform_tools.platform_role_management("get", role_id=None)
+    assert res == {"error": "role_id required for get"}
+
+
+def test_platform_role_management_update_missing_pieces(monkeypatch):
+    """``update`` without role_id or data (covers line 547)."""
+    _stub_post_safety(monkeypatch)
+    assert user_platform_tools.platform_role_management(
+        "update", role_id=None, data={"x": 1}
+    ) == {"error": "role_id and data required for update"}
+    assert user_platform_tools.platform_role_management(
+        "update", role_id="r", data=None
+    ) == {"error": "role_id and data required for update"}
+
+
+def test_platform_role_management_delete_missing_role_id(monkeypatch):
+    """``delete`` without role_id (covers line 561)."""
+    _stub_post_safety(monkeypatch)
+    res = user_platform_tools.platform_role_management("delete", role_id=None)
+    assert res == {"error": "role_id required for delete"}
+
+
+def test_platform_role_management_unknown_action(monkeypatch):
+    """Unknown action (covers line 572)."""
+    _stub_post_safety(monkeypatch)
+    res = user_platform_tools.platform_role_management("frobnicate")
+    assert res == {"error": "Unknown action: frobnicate"}
+
+
+def test_platform_role_management_create_dict_result_with_rowkey(monkeypatch):
+    """The Result-is-dict branch extracts _RowKey (covers lines 538-539)."""
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": "1"})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    def fake_post(url, **kwargs):
+        if "StoreRole" in url:
+            return DummyResponse(
+                {"success": True, "Result": {"_RowKey": "role-uuid-123"}}
+            )
+        return DummyResponse({"success": True, "Result": {"Results": []}})
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    res = user_platform_tools.platform_role_management(
+        "create", data={"Name": "Auditors"}
+    )
+    assert "result" in res
+    assert res["result"]["Result"]["_RowKey"] == "role-uuid-123"
+
+
+# --------------------------------------------------------------------------- #
+# user_platform_tools.platform_user_role_management error paths               #
+# --------------------------------------------------------------------------- #
+
+
+def test_platform_user_role_unconfigured(monkeypatch):
+    """RuntimeError from _build_headers surfaces (covers lines 631-632)."""
+    monkeypatch.setattr(user_platform_tools, "_headers", None)
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", None)
+    monkeypatch.setattr(user_platform_tools, "platform_service_account", None)
+    monkeypatch.setattr(user_platform_tools, "platform_service_password", None)
+    res = user_platform_tools.platform_user_role_management("list", role_id="r")
+    assert "error" in res
+    assert "Platform is not configured" in res["error"]
+
+
+def test_platform_user_role_unknown_action(monkeypatch):
+    """Unknown action raises ValueError caught and returned as error
+    (covers line 662)."""
+    _stub_post_safety(monkeypatch)
+    res = user_platform_tools.platform_user_role_management("frobnicate", role_id="r")
+    assert res == {"error": "Unknown action: frobnicate"}
+
+
+# --------------------------------------------------------------------------- #
+# user_platform_tools._endpoint_not_available                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_endpoint_not_available_detects_404():
+    assert user_platform_tools._endpoint_not_available(DummyResponse(status_code=404))
+
+
+def test_endpoint_not_available_passes_2xx_and_5xx():
+    assert not user_platform_tools._endpoint_not_available(
+        DummyResponse(status_code=200)
+    )
+    assert not user_platform_tools._endpoint_not_available(
+        DummyResponse(status_code=500)
+    )
+
+
+# --------------------------------------------------------------------------- #
+# tools.bulk_user_response invalid JSON string                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_bulk_user_response_invalid_json_user_ids(monkeypatch):
+    """A non-JSON string for user_ids is rejected (covers lines 1966-1967)."""
+    monkeypatch.setattr(SessionManager, "_session", Mock())
+    res = tools.bulk_user_response(
+        user_ids="not-a-json-list", scenario="force_logout", comment="why"
+    )
+    assert "error" in res
+    assert "JSON-encoded list" in res["error"]
+
+
+# --------------------------------------------------------------------------- #
+# tools.search drops records with no extractable id                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_tools_search_skips_records_without_id(monkeypatch):
+    """A record with no id/userId/folderId/groupId/roleId is skipped
+    (covers line 1598)."""
+    # Configure search to include the 'secret' kind only.
+    tools.configure({"search_objects": ["secret"], "delinea_base_url": "https://x"})
+
+    def fake_search_secrets(query):
+        return {
+            "records": [
+                {"name": "no-id-here"},  # missing all id-shaped keys -> skipped
+                {"id": 7, "name": "real"},  # included
+            ]
+        }
+
+    monkeypatch.setattr(tools, "search_secrets", fake_search_secrets)
+    res = tools.search("q")
+    assert {r["id"] for r in res["results"]} == {"secret/7"}
+
+
+# --------------------------------------------------------------------------- #
+# tools.fetch unknown kind                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_tools_fetch_unknown_kind():
+    """fetch() with an unknown object type raises ValueError (covers 1668)."""
+    tools.configure({"fetch_objects": ["secret", "spaceship"]})
+    with pytest.raises(ValueError, match="unknown fetch type"):
+        tools.fetch("spaceship/1")
+    # Restore default to avoid bleed-through to other tests.
+    tools.configure({"fetch_objects": ["secret"]})

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -33,25 +33,28 @@ def patch_request(monkeypatch, expected_calls, responses=None):
     monkeypatch.setattr(SessionManager, "_session", mock_session)
 
 
-def test_user_management(monkeypatch):
+def test_secretserver_local_user_management(monkeypatch):
+    """The renamed SS-local user_management still exercises /v1/users/*."""
     patch_request(
         monkeypatch,
         [("POST", "/v1/users", {"json": {"n": 1}}), ("GET", "/v1/users/99", {})],
         responses=[{"id": 99}, {"ok": True}],
     )
-    assert server.user_management("create", data={"n": 1}) == {
+    assert server.secretserver_local_user_management("create", data={"n": 1}) == {
         "result": {"id": 99},
         "verification": {"ok": True},
     }
 
     patch_request(monkeypatch, [("GET", "/v1/users/2", {})])
-    assert server.user_management("get", user_id=2) == {"ok": True}
+    assert server.secretserver_local_user_management("get", user_id=2) == {"ok": True}
 
     patch_request(
         monkeypatch,
         [("PUT", "/v1/users/3", {"json": {"a": 1}}), ("GET", "/v1/users/3", {})],
     )
-    assert server.user_management("update", user_id=3, data={"a": 1}) == {
+    assert server.secretserver_local_user_management(
+        "update", user_id=3, data={"a": 1}
+    ) == {
         "result": {"ok": True},
         "verification": {"ok": True},
     }
@@ -60,7 +63,7 @@ def test_user_management(monkeypatch):
         monkeypatch,
         [("DELETE", "/v1/users/4", {}), ("GET", "/v1/users/4", {})],
     )
-    assert server.user_management("delete", user_id=4) == {
+    assert server.secretserver_local_user_management("delete", user_id=4) == {
         "result": {"ok": True},
         "verification": {"ok": True},
     }
@@ -68,20 +71,24 @@ def test_user_management(monkeypatch):
     patch_request(
         monkeypatch, ("GET", "/v1/users/sessions", {"params": {"skip": 0, "take": 20}})
     )
-    assert server.user_management("list_sessions") == {"ok": True}
+    assert server.secretserver_local_user_management("list_sessions") == {"ok": True}
 
     patch_request(monkeypatch, ("POST", "/v1/users/5/reset-two-factor", {"json": {}}))
-    assert server.user_management("reset_2fa", user_id=5) == {"ok": True}
+    assert server.secretserver_local_user_management("reset_2fa", user_id=5) == {
+        "ok": True
+    }
 
     patch_request(
         monkeypatch, ("POST", "/v1/users/6/password-reset", {"json": {"p": 1}})
     )
-    assert server.user_management("reset_password", user_id=6, data={"p": 1}) == {
-        "ok": True
-    }
+    assert server.secretserver_local_user_management(
+        "reset_password", user_id=6, data={"p": 1}
+    ) == {"ok": True}
 
     patch_request(monkeypatch, ("POST", "/v1/users/7/lock-out", {"json": {}}))
-    assert server.user_management("lock_out", user_id=7) == {"ok": True}
+    assert server.secretserver_local_user_management("lock_out", user_id=7) == {
+        "ok": True
+    }
 
 
 def test_role_management(monkeypatch):

--- a/tests/test_new_flows.py
+++ b/tests/test_new_flows.py
@@ -27,9 +27,10 @@ from delinea_mcp.session import SessionManager
 
 
 class DummyResponse:
-    def __init__(self, data=None, content=b"x"):
+    def __init__(self, data=None, content=b"x", status_code=200):
         self._data = data if data is not None else {"ok": True}
         self.content = content
+        self.status_code = status_code
 
     def json(self):
         return self._data
@@ -466,21 +467,97 @@ def test_platform_role_management_get_filters_by_name(monkeypatch):
 
 
 @pytest.mark.parametrize("action", ["create", "update", "delete"])
-def test_platform_role_management_write_actions_return_unsupported(monkeypatch, action):
-    """Mutations need a different OAuth scope or admin UI on modern tenants."""
-    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+def test_platform_role_management_write_falls_back_on_404(monkeypatch, action):
+    """When the legacy SaasManage/Roles endpoint returns 404, the tool
+    returns a structured guidance error.  But the request IS attempted —
+    we don't refuse unconditionally."""
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": "1"})
     monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
 
-    def fake_post(*a, **kw):
-        raise AssertionError("no API calls expected on unsupported actions")
+    calls = []
+
+    def fake_post(url, **kwargs):
+        calls.append(url)
+        return DummyResponse(data={}, status_code=404)
 
     monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
     res = user_platform_tools.platform_role_management(
         action, role_id="role-1", data={"Name": "x"}
     )
+    assert calls, "tool must attempt the endpoint before falling back"
     assert "error" in res
-    assert "not exposed" in res["error"]
-    assert "role_management" in res["error"]  # points at SS-side fallback
+    assert "404" in res["error"]
+    assert "role_management" in res["error"]
+
+
+def test_platform_role_management_create_success_on_supporting_tenant(monkeypatch):
+    """When SaasManage/StoreRole returns success, the tool returns the result.
+
+    Verifies tenants that DO expose role mutations aren't locked out by
+    the fallback logic.
+    """
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": "1"})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    posts = []
+
+    def fake_post(url, **kwargs):
+        posts.append((url, kwargs.get("json")))
+        if "StoreRole" in url:
+            return DummyResponse({"success": True, "Result": "role-abc"})
+        # Verification 'get' uses Report/RunReport
+        return DummyResponse({"success": True, "Result": {"Results": []}})
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    res = user_platform_tools.platform_role_management(
+        "create", data={"Name": "Auditors", "Description": "RO"}
+    )
+    assert "result" in res
+    assert res["result"].get("Result") == "role-abc"
+    assert any("/SaasManage/StoreRole" in u for u, _ in posts)
+
+
+def test_platform_role_management_update_success_on_supporting_tenant(monkeypatch):
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": "1"})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    posts = []
+
+    def fake_post(url, **kwargs):
+        posts.append((url, kwargs.get("json")))
+        return DummyResponse({"success": True, "Result": {"Updated": True}})
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    res = user_platform_tools.platform_role_management(
+        "update", role_id="role-1", data={"Description": "new desc"}
+    )
+    assert "result" in res
+    update_body = next(b for u, b in posts if "/Roles/UpdateRole" in u)
+    assert update_body == {"Name": "role-1", "Description": "new desc"}
+
+
+def test_platform_role_management_delete_success_on_supporting_tenant(monkeypatch):
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": "1"})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    posts = []
+
+    def fake_post(url, **kwargs):
+        posts.append((url, kwargs.get("json")))
+        return DummyResponse({"success": True, "Result": {"Deleted": True}})
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    res = user_platform_tools.platform_role_management("delete", role_id="role-1")
+    assert "result" in res
+    delete_body = next(b for u, b in posts if "/SaasManage/RemoveRole" in u)
+    assert delete_body == {"Name": "role-1"}
+
+
+def test_platform_role_management_create_requires_name(monkeypatch):
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": "1"})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+    res = user_platform_tools.platform_role_management("create", data={})
+    assert "error" in res and "'Name' required" in res["error"]
 
 
 # --------------------------------------------------------------------------- #
@@ -507,26 +584,64 @@ def test_platform_user_role_list_uses_canned_report(monkeypatch):
 
 
 @pytest.mark.parametrize("action", ["add", "remove"])
-def test_platform_user_role_mutations_return_unsupported(monkeypatch, action):
-    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+def test_platform_user_role_mutations_fall_back_on_404(monkeypatch, action):
+    """Add/remove are attempted; on HTTP 404 the tool surfaces guidance."""
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": "1"})
     monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
 
-    def fake_post(*a, **kw):
-        raise AssertionError("no API calls expected on unsupported mutations")
+    calls = []
+
+    def fake_post(url, **kwargs):
+        calls.append(url)
+        return DummyResponse(data={}, status_code=404)
 
     monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
     res = user_platform_tools.platform_user_role_management(
         action, role_id="role-1", user_principals=["alice@t"]
     )
+    assert calls, "tool must attempt the endpoint before falling back"
     assert "error" in res
-    assert "not exposed" in res["error"]
+    assert "404" in res["error"]
     assert "user_role_management" in res["error"]
+
+
+@pytest.mark.parametrize("action,key", [("add", "Add"), ("remove", "Delete")])
+def test_platform_user_role_mutations_success_on_supporting_tenant(
+    monkeypatch, action, key
+):
+    """On tenants exposing Roles/UpdateRole the tool returns the real result."""
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": "1"})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    posts = []
+
+    def fake_post(url, **kwargs):
+        posts.append((url, kwargs.get("json")))
+        return DummyResponse({"success": True, "Result": {"Updated": True}})
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    res = user_platform_tools.platform_user_role_management(
+        action, role_id="role-1", user_principals=["alice@t", "bob@t"]
+    )
+    assert "result" in res
+    update_body = next(b for u, b in posts if "/Roles/UpdateRole" in u)
+    assert update_body == {
+        "Name": "role-1",
+        "Users": {key: ["alice@t", "bob@t"]},
+    }
+
+
+def test_platform_user_role_add_requires_principals(monkeypatch):
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": "1"})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+    res = user_platform_tools.platform_user_role_management("add", role_id="role-1")
+    assert "error" in res and "user_principals required" in res["error"]
 
 
 def test_platform_user_role_principals_accepts_json_string(monkeypatch):
     """The JSON-string parsing branch still runs even though list is the only
     real path now — keep coverage for the input-validation logic."""
-    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": "1"})
     monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
     # Bad JSON should produce a parsing error before any HTTP call.
 

--- a/tests/test_new_flows.py
+++ b/tests/test_new_flows.py
@@ -14,6 +14,8 @@ import os
 import sys
 from unittest.mock import Mock
 
+import pytest
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import server
 from delinea_mcp import tools, user_platform_tools
@@ -417,97 +419,78 @@ def test_user_management_returns_helpful_error_when_unconfigured(monkeypatch):
 
 # --------------------------------------------------------------------------- #
 # platform_role_management                                                    #
+#                                                                             #
+# On modern Delinea Platform tenants role write ops aren't exposed via the    #
+# xpmheadless OAuth scope; the tool returns a structured error.  Read ops     #
+# (list, get) use the canned Report/RunReport pattern.                        #
 # --------------------------------------------------------------------------- #
 
 
-def test_platform_role_management_create_uses_storerole(monkeypatch):
+def test_platform_role_management_list_uses_canned_report(monkeypatch):
     monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
     monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
 
-    posts = []
+    captured = []
 
     def fake_post(url, **kwargs):
-        posts.append((url, kwargs.get("json")))
-        if "StoreRole" in url:
-            return DummyResponse({"Result": {"_RowKey": "role-abc"}})
-        # Verification 'get' call
-        return DummyResponse({"Result": {"Results": [{"Row": {"ID": "role-abc"}}]}})
+        captured.append((url, kwargs.get("json")))
+        return DummyResponse(
+            {"success": True, "Result": {"Results": [{"Row": {"Name": "Everybody"}}]}}
+        )
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    res = user_platform_tools.platform_role_management("list")
+    assert "/api/Report/RunReport" in captured[0][0]
+    assert captured[0][1]["ID"] == "role_searchbyname"
+    # The Args.Parameters should carry the search string (default "%" for list-all)
+    params = captured[0][1]["Args"]["Parameters"]
+    assert any(p["Name"] == "searchString" for p in params)
+    assert res.get("success") is True
+
+
+def test_platform_role_management_get_filters_by_name(monkeypatch):
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    captured = []
+
+    def fake_post(url, **kwargs):
+        captured.append((url, kwargs.get("json")))
+        return DummyResponse({"success": True, "Result": {"Results": []}})
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    user_platform_tools.platform_role_management("get", role_id="Auditors")
+    params = captured[0][1]["Args"]["Parameters"]
+    search_value = next(p["Value"] for p in params if p["Name"] == "searchString")
+    assert search_value == "Auditors"
+
+
+@pytest.mark.parametrize("action", ["create", "update", "delete"])
+def test_platform_role_management_write_actions_return_unsupported(monkeypatch, action):
+    """Mutations need a different OAuth scope or admin UI on modern tenants."""
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    def fake_post(*a, **kw):
+        raise AssertionError("no API calls expected on unsupported actions")
 
     monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
     res = user_platform_tools.platform_role_management(
-        "create", data={"Name": "Auditors", "Description": "RO"}
+        action, role_id="role-1", data={"Name": "x"}
     )
-    assert "result" in res
-    assert "/SaasManage/StoreRole" in posts[0][0]
-    assert posts[0][1] == {"Name": "Auditors", "Description": "RO"}
-
-
-def test_platform_role_management_update_calls_updaterole(monkeypatch):
-    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
-    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
-
-    posts = []
-
-    def fake_post(url, **kwargs):
-        posts.append((url, kwargs.get("json")))
-        return DummyResponse({"Result": {"Success": True}})
-
-    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
-    user_platform_tools.platform_role_management(
-        "update", role_id="role-1", data={"Description": "new"}
-    )
-    assert any("Roles/UpdateRole" in u for u, _ in posts)
-    update_body = next(b for u, b in posts if "Roles/UpdateRole" in u)
-    assert update_body == {"Name": "role-1", "Description": "new"}
-
-
-def test_platform_role_management_list_uses_redrock(monkeypatch):
-    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
-    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
-
-    captured = []
-
-    def fake_post(url, **kwargs):
-        captured.append((url, kwargs.get("json")))
-        return DummyResponse({"Result": {"Results": []}})
-
-    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
-    user_platform_tools.platform_role_management("list")
-    assert "/Redrock/Query" in captured[0][0]
-    assert "FROM Role" in captured[0][1]["Script"]
-
-
-def test_platform_role_management_delete_uses_removerole(monkeypatch):
-    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
-    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
-
-    captured = []
-
-    def fake_post(url, **kwargs):
-        captured.append((url, kwargs.get("json")))
-        return DummyResponse({"Result": {"Success": True}})
-
-    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
-    res = user_platform_tools.platform_role_management("delete", role_id="role-1")
-    assert "result" in res
-    assert any("RemoveRole" in u for u, _ in captured)
-    delete_body = next(b for u, b in captured if "RemoveRole" in u)
-    assert delete_body == {"Name": "role-1"}
-
-
-def test_platform_role_management_create_requires_name(monkeypatch):
-    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
-    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
-    res = user_platform_tools.platform_role_management("create", data={})
-    assert "error" in res and "'Name' required" in res["error"]
+    assert "error" in res
+    assert "not exposed" in res["error"]
+    assert "role_management" in res["error"]  # points at SS-side fallback
 
 
 # --------------------------------------------------------------------------- #
 # platform_user_role_management                                               #
+#                                                                             #
+# Same constraints — reads via canned report; writes unsupported.             #
 # --------------------------------------------------------------------------- #
 
 
-def test_platform_user_role_add_uses_updaterole_users_add(monkeypatch):
+def test_platform_user_role_list_uses_canned_report(monkeypatch):
     monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
     monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
 
@@ -515,61 +498,47 @@ def test_platform_user_role_add_uses_updaterole_users_add(monkeypatch):
 
     def fake_post(url, **kwargs):
         captured.append((url, kwargs.get("json")))
-        return DummyResponse({"Result": {"Success": True}})
-
-    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
-    res = user_platform_tools.platform_user_role_management(
-        "add", role_id="role-1", user_principals=["alice@t", "bob@t"]
-    )
-    assert "result" in res
-    update_body = next(b for u, b in captured if "Roles/UpdateRole" in u)
-    assert update_body == {
-        "Name": "role-1",
-        "Users": {"Add": ["alice@t", "bob@t"]},
-    }
-
-
-def test_platform_user_role_remove_uses_users_delete(monkeypatch):
-    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
-    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
-
-    captured = []
-
-    def fake_post(url, **kwargs):
-        captured.append((url, kwargs.get("json")))
-        return DummyResponse({"Result": {"Success": True}})
-
-    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
-    user_platform_tools.platform_user_role_management(
-        "remove", role_id="role-1", user_principals=["alice@t"]
-    )
-    update_body = next(b for u, b in captured if "Roles/UpdateRole" in u)
-    assert update_body == {
-        "Name": "role-1",
-        "Users": {"Delete": ["alice@t"]},
-    }
-
-
-def test_platform_user_role_add_requires_principals(monkeypatch):
-    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
-    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
-    res = user_platform_tools.platform_user_role_management("add", role_id="role-1")
-    assert "error" in res and "user_principals required" in res["error"]
-
-
-def test_platform_user_role_list_uses_redrock(monkeypatch):
-    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
-    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
-
-    captured = []
-
-    def fake_post(url, **kwargs):
-        captured.append((url, kwargs.get("json")))
-        return DummyResponse({"Result": {"Results": []}})
+        return DummyResponse({"success": True, "Result": {"Results": []}})
 
     monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
     user_platform_tools.platform_user_role_management("list", role_id="role-1")
-    assert any("/Redrock/Query" in u for u, _ in captured)
+    assert any("/api/Report/RunReport" in u for u, _ in captured)
+    assert captured[0][1]["ID"] == "role_searchbyname"
+
+
+@pytest.mark.parametrize("action", ["add", "remove"])
+def test_platform_user_role_mutations_return_unsupported(monkeypatch, action):
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    def fake_post(*a, **kw):
+        raise AssertionError("no API calls expected on unsupported mutations")
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    res = user_platform_tools.platform_user_role_management(
+        action, role_id="role-1", user_principals=["alice@t"]
+    )
+    assert "error" in res
+    assert "not exposed" in res["error"]
+    assert "user_role_management" in res["error"]
+
+
+def test_platform_user_role_principals_accepts_json_string(monkeypatch):
+    """The JSON-string parsing branch still runs even though list is the only
+    real path now — keep coverage for the input-validation logic."""
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+    # Bad JSON should produce a parsing error before any HTTP call.
+
+    def fake_post(*a, **kw):
+        raise AssertionError("no API call expected on parse error")
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    res = user_platform_tools.platform_user_role_management(
+        "add", role_id="role-1", user_principals="not-json"
+    )
+    assert "error" in res
+    assert "JSON-encoded list" in res["error"]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_new_flows.py
+++ b/tests/test_new_flows.py
@@ -1,0 +1,618 @@
+"""Unit tests for tools introduced in v1.0.0:
+
+- ``update_secret_fields``
+- ``bulk_user_response``
+- ``platform_role_management``
+- ``platform_user_role_management``
+- ``user_management`` / ``search_users`` (Platform-canonical, with the
+  legacy ``platform_user_management`` alias)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import Mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import server
+from delinea_mcp import tools, user_platform_tools
+from delinea_mcp.session import SessionManager
+
+# --------------------------------------------------------------------------- #
+# Shared helpers (mirrors test_management.py patterns)                        #
+# --------------------------------------------------------------------------- #
+
+
+class DummyResponse:
+    def __init__(self, data=None, content=b"x"):
+        self._data = data if data is not None else {"ok": True}
+        self.content = content
+
+    def json(self):
+        return self._data
+
+
+def patch_request(monkeypatch, expected_calls, responses=None):
+    if expected_calls and isinstance(expected_calls[0], str):
+        expected_calls = [expected_calls]
+    calls = list(expected_calls)
+    resps = list(responses or [None] * len(calls))
+
+    def fake_request(method, path, **kwargs):
+        exp_method, exp_path, exp_kwargs = calls.pop(0)
+        assert method == exp_method, f"expected {exp_method} got {method}"
+        assert path == exp_path, f"expected {exp_path} got {path}"
+        assert kwargs == exp_kwargs, f"expected {exp_kwargs} got {kwargs}"
+        data = resps.pop(0)
+        return DummyResponse(data)
+
+    mock_session = Mock()
+    mock_session.request = fake_request
+    monkeypatch.setattr(SessionManager, "_session", mock_session)
+
+
+# --------------------------------------------------------------------------- #
+# update_secret_fields                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_update_secret_fields_happy_path(monkeypatch):
+    """Read summary, fetch template, PUT each non-password field, verify."""
+    patch_request(
+        monkeypatch,
+        [
+            # 1. approval pre-check
+            ("GET", "/v1/secrets/42/summary", {}),
+            # 2. fetch secret to discover template id
+            ("GET", "/v2/secrets/42", {}),
+            # 3. fetch template to enumerate fields
+            ("GET", "/v1/secret-templates/9000", {}),
+            # 4. PUT each non-password field
+            ("PUT", "/v1/secrets/42/fields/notes", {"json": {"value": "n"}}),
+            ("PUT", "/v1/secrets/42/fields/url", {"json": {"value": "https://x"}}),
+            # 5. verification summary
+            ("GET", "/v1/secrets/42/summary", {}),
+        ],
+        responses=[
+            {"id": 42, "requiresApproval": False, "requiresComment": False},
+            {"id": 42, "secretTemplateId": 9000},
+            {
+                "fields": [
+                    {"fieldSlugName": "notes", "isPassword": False},
+                    {"fieldSlugName": "url", "isPassword": False},
+                    {"fieldSlugName": "password", "isPassword": True},
+                ]
+            },
+            {"ok": True},
+            {"ok": True},
+            {"id": 42, "name": "ok"},
+        ],
+    )
+    result = server.update_secret_fields(
+        secret_id=42,
+        field_updates={"notes": "n", "url": "https://x"},
+    )
+    assert result["result"]["secret_id"] == 42
+    assert result["result"]["all_updated"] is True
+    assert {f["slug"] for f in result["result"]["fields"]} == {"notes", "url"}
+    assert result["verification"]["id"] == 42
+
+
+def test_update_secret_fields_rejects_password_slug(monkeypatch):
+    """A slug whose template field has isPassword=True is refused by default."""
+    patch_request(
+        monkeypatch,
+        [
+            ("GET", "/v1/secrets/42/summary", {}),
+            ("GET", "/v2/secrets/42", {}),
+            ("GET", "/v1/secret-templates/9000", {}),
+        ],
+        responses=[
+            {"id": 42, "requiresApproval": False, "requiresComment": False},
+            {"id": 42, "secretTemplateId": 9000},
+            {
+                "fields": [
+                    {"fieldSlugName": "password", "isPassword": True},
+                    {"fieldSlugName": "notes", "isPassword": False},
+                ]
+            },
+        ],
+    )
+    result = server.update_secret_fields(
+        secret_id=42,
+        field_updates={"password": "leaked!"},
+    )
+    assert "error" in result
+    assert "password-class" in result["error"]
+
+
+def test_update_secret_fields_password_override_emits_value(monkeypatch):
+    """allow_password_fields=True bypasses the safety gate."""
+    patch_request(
+        monkeypatch,
+        [
+            ("GET", "/v1/secrets/42/summary", {}),
+            (
+                "PUT",
+                "/v1/secrets/42/fields/password",
+                {"json": {"value": "new-pwd"}},
+            ),
+            ("GET", "/v1/secrets/42/summary", {}),
+        ],
+        responses=[
+            {"id": 42, "requiresApproval": False, "requiresComment": False},
+            {"ok": True},
+            {"id": 42, "name": "ok"},
+        ],
+    )
+    result = server.update_secret_fields(
+        secret_id=42,
+        field_updates={"password": "new-pwd"},
+        allow_password_fields=True,
+    )
+    assert result["result"]["all_updated"] is True
+
+
+def test_update_secret_fields_requires_approval_returns_error(monkeypatch):
+    patch_request(
+        monkeypatch,
+        [("GET", "/v1/secrets/42/summary", {})],
+        responses=[{"id": 42, "requiresApproval": True}],
+    )
+    result = server.update_secret_fields(secret_id=42, field_updates={"notes": "n"})
+    assert "error" in result and "requires approval" in result["error"]
+
+
+def test_update_secret_fields_with_comment_passes_audit_params(monkeypatch):
+    """When a comment is supplied, the PUT includes autoCheckout/autoComment."""
+    patch_request(
+        monkeypatch,
+        [
+            ("GET", "/v1/secrets/42/summary", {}),
+            ("GET", "/v2/secrets/42", {}),
+            ("GET", "/v1/secret-templates/9000", {}),
+            (
+                "PUT",
+                "/v1/secrets/42/fields/notes",
+                {
+                    "json": {"value": "n"},
+                    "params": {
+                        "autoCheckout": "true",
+                        "autoCheckIn": "true",
+                        "autoComment": "JIRA-1: doc fix",
+                    },
+                },
+            ),
+            ("GET", "/v1/secrets/42/summary", {}),
+        ],
+        responses=[
+            {"id": 42, "requiresComment": True},
+            {"id": 42, "secretTemplateId": 9000},
+            {"fields": [{"fieldSlugName": "notes", "isPassword": False}]},
+            {"ok": True},
+            {"id": 42},
+        ],
+    )
+    result = server.update_secret_fields(
+        secret_id=42,
+        field_updates={"notes": "n"},
+        comment="JIRA-1: doc fix",
+    )
+    assert result["result"]["all_updated"] is True
+
+
+def test_update_secret_fields_rejects_empty_updates(monkeypatch):
+    monkeypatch.setattr(SessionManager, "_session", Mock())
+    result = server.update_secret_fields(secret_id=1, field_updates={})
+    assert "error" in result
+    assert "non-empty" in result["error"]
+
+
+def test_update_secret_fields_accepts_json_string(monkeypatch):
+    """field_updates may be a JSON-encoded mapping."""
+    patch_request(
+        monkeypatch,
+        [
+            ("GET", "/v1/secrets/42/summary", {}),
+            ("GET", "/v2/secrets/42", {}),
+            ("GET", "/v1/secret-templates/9000", {}),
+            ("PUT", "/v1/secrets/42/fields/notes", {"json": {"value": "n"}}),
+            ("GET", "/v1/secrets/42/summary", {}),
+        ],
+        responses=[
+            {"id": 42, "requiresApproval": False, "requiresComment": False},
+            {"id": 42, "secretTemplateId": 9000},
+            {"fields": [{"fieldSlugName": "notes", "isPassword": False}]},
+            {"ok": True},
+            {"id": 42},
+        ],
+    )
+    result = server.update_secret_fields(secret_id=42, field_updates='{"notes": "n"}')
+    assert result["result"]["all_updated"] is True
+
+
+# --------------------------------------------------------------------------- #
+# bulk_user_response                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_bulk_user_response_preview_without_confirm(monkeypatch):
+    """confirm=False returns a preview and makes no API calls."""
+    sentinel = Mock()
+    sentinel.request.side_effect = AssertionError("no API calls expected on preview")
+    monkeypatch.setattr(SessionManager, "_session", sentinel)
+    out = server.bulk_user_response(
+        user_ids=[1, 2, 3], scenario="compromise", comment="INC-7"
+    )
+    assert "preview" in out
+    assert out["preview"]["scenario"] == "compromise"
+    assert out["preview"]["user_count"] == 3
+    assert "force_logout" in out["preview"]["steps"]
+
+
+def test_bulk_user_response_rejects_unknown_scenario(monkeypatch):
+    monkeypatch.setattr(SessionManager, "_session", Mock())
+    out = server.bulk_user_response([1], scenario="nuke", comment="why")
+    assert "error" in out and "Unknown scenario" in out["error"]
+
+
+def test_bulk_user_response_rejects_missing_comment(monkeypatch):
+    monkeypatch.setattr(SessionManager, "_session", Mock())
+    out = server.bulk_user_response([1], scenario="force_logout", comment="")
+    assert "error" in out and "comment is required" in out["error"]
+
+
+def test_bulk_user_response_rejects_empty_user_list(monkeypatch):
+    monkeypatch.setattr(SessionManager, "_session", Mock())
+    out = server.bulk_user_response([], scenario="force_logout", comment="why")
+    assert "error" in out and "non-empty list" in out["error"]
+
+
+def test_bulk_user_response_compromise_executes_in_order(monkeypatch):
+    """Confirmed compromise scenario runs each step then verifies user state."""
+    expected_body = {"data": {"userIds": [10, 20]}}
+    patch_request(
+        monkeypatch,
+        [
+            ("POST", "/v1/bulk-user-operations/force-logout", {"json": expected_body}),
+            ("POST", "/v1/bulk-user-operations/lock", {"json": expected_body}),
+            ("POST", "/v1/bulk-user-operations/disable", {"json": expected_body}),
+            (
+                "POST",
+                "/v1/bulk-user-operations/reset-fido2-two-factor",
+                {"json": expected_body},
+            ),
+            (
+                "POST",
+                "/v1/bulk-user-operations/reset-totp-auth",
+                {"json": expected_body},
+            ),
+            ("GET", "/v1/users/10", {}),
+            ("GET", "/v1/users/20", {}),
+        ],
+        responses=[
+            {"success": True},
+            {"success": True},
+            {"success": True},
+            {"success": True},
+            {"success": True},
+            {"id": 10, "enabled": False, "isLockedOut": True, "lastLogin": None},
+            {"id": 20, "enabled": False, "isLockedOut": True, "lastLogin": None},
+        ],
+    )
+    out = server.bulk_user_response(
+        user_ids=[10, 20],
+        scenario="compromise",
+        comment="INC-42 verified compromise",
+        confirm=True,
+    )
+    assert out["result"]["all_ok"] is True
+    assert [s["step"] for s in out["result"]["steps"]] == [
+        "force_logout",
+        "lock",
+        "disable",
+        "reset_fido2",
+        "reset_totp",
+    ]
+    assert all(v["enabled"] is False for v in out["verification"])
+
+
+def test_bulk_user_response_offboard_skips_2fa_resets(monkeypatch):
+    """Offboard scenario does not strip 2FA factors (audit trail concern)."""
+    expected_body = {"data": {"userIds": [99]}}
+    patch_request(
+        monkeypatch,
+        [
+            ("POST", "/v1/bulk-user-operations/force-logout", {"json": expected_body}),
+            ("POST", "/v1/bulk-user-operations/disable", {"json": expected_body}),
+            ("GET", "/v1/users/99", {}),
+        ],
+        responses=[
+            {"success": True},
+            {"success": True},
+            {"id": 99, "enabled": False, "isLockedOut": False},
+        ],
+    )
+    out = server.bulk_user_response(
+        user_ids=[99],
+        scenario="offboard",
+        comment="HR-555 offboarding",
+        confirm=True,
+    )
+    assert [s["step"] for s in out["result"]["steps"]] == ["force_logout", "disable"]
+
+
+def test_bulk_user_response_accepts_json_string(monkeypatch):
+    monkeypatch.setattr(SessionManager, "_session", Mock())
+    out = server.bulk_user_response(
+        user_ids="[1,2]", scenario="force_logout", comment="why"
+    )
+    # No confirm => preview, but parsing should succeed.
+    assert out["preview"]["user_count"] == 2
+
+
+def test_bulk_user_response_rejects_non_int_ids(monkeypatch):
+    monkeypatch.setattr(SessionManager, "_session", Mock())
+    out = server.bulk_user_response(
+        user_ids=["not-an-int"], scenario="force_logout", comment="why"
+    )
+    assert "error" in out and "integers" in out["error"]
+
+
+# --------------------------------------------------------------------------- #
+# Platform user_management / search_users                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_platform_user_management_canonical_alias(monkeypatch):
+    """user_management is the canonical name; platform_user_management is alias."""
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    captured = []
+
+    def fake_post(url, **kwargs):
+        captured.append(url)
+        return DummyResponse({"ok": True})
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    res = user_platform_tools.user_management("create", data={"Name": "u"})
+    assert res == {"result": {"ok": True}, "verification": {"ok": True}}
+
+    # Alias goes to the same place.
+    res2 = user_platform_tools.platform_user_management("create", data={"Name": "u"})
+    assert res2 == {"result": {"ok": True}, "verification": {"ok": True}}
+
+    assert all("CreateUser" in u for u in captured if "CreateUser" in u)
+
+
+def test_platform_search_users_uses_canned_report(monkeypatch):
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    captured = []
+
+    def fake_post(url, **kwargs):
+        captured.append((url, kwargs.get("json")))
+        return DummyResponse({"records": [{"Username": "alice"}]})
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    res = user_platform_tools.search_users("alice")
+    assert "records" in res
+    assert "RunReport" in captured[0][0]
+    assert captured[0][1]["ID"] == "user_searchbyname"
+
+
+def test_user_management_returns_helpful_error_when_unconfigured(monkeypatch):
+    """When Platform isn't configured, user_management explains how to fix it."""
+    monkeypatch.setattr(user_platform_tools, "_headers", None)
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", None)
+    monkeypatch.setattr(user_platform_tools, "platform_service_account", None)
+    monkeypatch.setattr(user_platform_tools, "platform_service_password", None)
+    res = user_platform_tools.user_management("get", user_id="x")
+    assert "error" in res
+    assert "secretserver_local_user_management" in res["error"]
+
+
+# --------------------------------------------------------------------------- #
+# platform_role_management                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_platform_role_management_create_uses_storerole(monkeypatch):
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    posts = []
+
+    def fake_post(url, **kwargs):
+        posts.append((url, kwargs.get("json")))
+        if "StoreRole" in url:
+            return DummyResponse({"Result": {"_RowKey": "role-abc"}})
+        # Verification 'get' call
+        return DummyResponse({"Result": {"Results": [{"Row": {"ID": "role-abc"}}]}})
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    res = user_platform_tools.platform_role_management(
+        "create", data={"Name": "Auditors", "Description": "RO"}
+    )
+    assert "result" in res
+    assert "/SaasManage/StoreRole" in posts[0][0]
+    assert posts[0][1] == {"Name": "Auditors", "Description": "RO"}
+
+
+def test_platform_role_management_update_calls_updaterole(monkeypatch):
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    posts = []
+
+    def fake_post(url, **kwargs):
+        posts.append((url, kwargs.get("json")))
+        return DummyResponse({"Result": {"Success": True}})
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    user_platform_tools.platform_role_management(
+        "update", role_id="role-1", data={"Description": "new"}
+    )
+    assert any("Roles/UpdateRole" in u for u, _ in posts)
+    update_body = next(b for u, b in posts if "Roles/UpdateRole" in u)
+    assert update_body == {"Name": "role-1", "Description": "new"}
+
+
+def test_platform_role_management_list_uses_redrock(monkeypatch):
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    captured = []
+
+    def fake_post(url, **kwargs):
+        captured.append((url, kwargs.get("json")))
+        return DummyResponse({"Result": {"Results": []}})
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    user_platform_tools.platform_role_management("list")
+    assert "/Redrock/Query" in captured[0][0]
+    assert "FROM Role" in captured[0][1]["Script"]
+
+
+def test_platform_role_management_delete_uses_removerole(monkeypatch):
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    captured = []
+
+    def fake_post(url, **kwargs):
+        captured.append((url, kwargs.get("json")))
+        return DummyResponse({"Result": {"Success": True}})
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    res = user_platform_tools.platform_role_management("delete", role_id="role-1")
+    assert "result" in res
+    assert any("RemoveRole" in u for u, _ in captured)
+    delete_body = next(b for u, b in captured if "RemoveRole" in u)
+    assert delete_body == {"Name": "role-1"}
+
+
+def test_platform_role_management_create_requires_name(monkeypatch):
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+    res = user_platform_tools.platform_role_management("create", data={})
+    assert "error" in res and "'Name' required" in res["error"]
+
+
+# --------------------------------------------------------------------------- #
+# platform_user_role_management                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_platform_user_role_add_uses_updaterole_users_add(monkeypatch):
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    captured = []
+
+    def fake_post(url, **kwargs):
+        captured.append((url, kwargs.get("json")))
+        return DummyResponse({"Result": {"Success": True}})
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    res = user_platform_tools.platform_user_role_management(
+        "add", role_id="role-1", user_principals=["alice@t", "bob@t"]
+    )
+    assert "result" in res
+    update_body = next(b for u, b in captured if "Roles/UpdateRole" in u)
+    assert update_body == {
+        "Name": "role-1",
+        "Users": {"Add": ["alice@t", "bob@t"]},
+    }
+
+
+def test_platform_user_role_remove_uses_users_delete(monkeypatch):
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    captured = []
+
+    def fake_post(url, **kwargs):
+        captured.append((url, kwargs.get("json")))
+        return DummyResponse({"Result": {"Success": True}})
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    user_platform_tools.platform_user_role_management(
+        "remove", role_id="role-1", user_principals=["alice@t"]
+    )
+    update_body = next(b for u, b in captured if "Roles/UpdateRole" in u)
+    assert update_body == {
+        "Name": "role-1",
+        "Users": {"Delete": ["alice@t"]},
+    }
+
+
+def test_platform_user_role_add_requires_principals(monkeypatch):
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+    res = user_platform_tools.platform_user_role_management("add", role_id="role-1")
+    assert "error" in res and "user_principals required" in res["error"]
+
+
+def test_platform_user_role_list_uses_redrock(monkeypatch):
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+    monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
+
+    captured = []
+
+    def fake_post(url, **kwargs):
+        captured.append((url, kwargs.get("json")))
+        return DummyResponse({"Result": {"Results": []}})
+
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
+    user_platform_tools.platform_user_role_management("list", role_id="role-1")
+    assert any("/Redrock/Query" in u for u, _ in captured)
+
+
+# --------------------------------------------------------------------------- #
+# Tool registration                                                           #
+# --------------------------------------------------------------------------- #
+
+
+class _DummyMCP:
+    def __init__(self):
+        self.names: list[str] = []
+
+    def tool(self):
+        def deco(f):
+            self.names.append(f.__name__)
+            return f
+
+        return deco
+
+
+def test_register_exposes_canonical_and_legacy_names():
+    """The Platform module registers canonical user_management + search_users."""
+    mcp = _DummyMCP()
+    user_platform_tools.register(mcp)
+    assert "user_management" in mcp.names
+    assert "search_users" in mcp.names
+    assert "platform_user_management" in mcp.names  # back-compat alias
+    assert "platform_role_management" in mcp.names
+    assert "platform_user_role_management" in mcp.names
+
+
+def test_register_ss_local_users():
+    from delinea_mcp import secretserver_users
+
+    mcp = _DummyMCP()
+    secretserver_users.register(mcp)
+    assert "secretserver_local_user_management" in mcp.names
+    assert "search_secretserver_local_users" in mcp.names
+
+
+def test_tools_module_exposes_new_flows():
+    """The new tools are present in tools.TOOLS so register() picks them up."""
+    names = [n for n, _ in tools.TOOLS]
+    assert "update_secret_fields" in names
+    assert "bulk_user_response" in names
+    assert "user_management" not in names  # moved to platform module
+    assert "search_users" not in names  # moved to platform module

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -62,6 +62,7 @@ def test_get_folder_children(monkeypatch):
 
 
 def test_user_details_and_search(monkeypatch):
+    """The legacy SS-local user tools still hit /v1/users (Platform-free path)."""
     calls = []
 
     def fake_request(self, method, path, **kwargs):
@@ -76,8 +77,8 @@ def test_user_details_and_search(monkeypatch):
 
     mock_session = type("MockSession", (), {"request": fake_request})()
     monkeypatch.setattr(SessionManager, "_session", mock_session)
-    user = server.user_management("get", user_id=2)
-    search = server.search_users("bob")
+    user = server.secretserver_local_user_management("get", user_id=2)
+    search = server.search_secretserver_local_users("bob")
     assert user == {"id": 2, "name": "bob"}
     assert search == {"records": []}
     assert calls[0][0] == "/v1/users/2"

--- a/tests/test_search_fetch.py
+++ b/tests/test_search_fetch.py
@@ -12,7 +12,8 @@ class DummySession:
         raise AssertionError("network")
 
 
-import delinea_mcp.tools as tools
+import delinea_mcp.secretserver_users as secretserver_users  # noqa: E402
+import delinea_mcp.tools as tools  # noqa: E402
 
 
 def setup_module(module):
@@ -49,7 +50,10 @@ def test_search_user_not_enabled(monkeypatch):
         called.append(q)
         return {}
 
-    monkeypatch.setattr(tools, "search_users", fake_search_users)
+    # User search routes through the SS-local module after the v1.0.0 split.
+    monkeypatch.setattr(
+        secretserver_users, "search_secretserver_local_users", fake_search_users
+    )
     tools.search("u")
     assert not called
 
@@ -58,8 +62,8 @@ def test_search_user_enabled(monkeypatch):
     tools.configure({"search_objects": ["secret", "user"]})
 
     monkeypatch.setattr(
-        tools,
-        "search_users",
+        secretserver_users,
+        "search_secretserver_local_users",
         lambda q: {"records": [{"id": 2, "username": "bob"}]},
     )
     res = tools.search("bob")
@@ -89,8 +93,8 @@ def test_fetch_secret(monkeypatch):
 def test_fetch_user_enabled(monkeypatch):
     tools.configure({"fetch_objects": ["secret", "user"]})
     monkeypatch.setattr(
-        tools,
-        "user_management",
+        secretserver_users,
+        "secretserver_local_user_management",
         lambda action, user_id=None, **_: (
             {"id": user_id, "username": "bob"} if action == "get" else None
         ),

--- a/tests/test_tools_additional.py
+++ b/tests/test_tools_additional.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from delinea_mcp import tools
+from delinea_mcp import secretserver_users, tools
 from delinea_mcp.session import SessionManager
 
 
@@ -26,9 +26,11 @@ def test_get_secret_template_field(monkeypatch):
 def test_user_management_extra(monkeypatch):
     s = Session()
     monkeypatch.setattr(SessionManager, "_session", s)
-    res = tools.user_management("list_sessions", skip=0, take=1, is_exporting=True)
+    res = secretserver_users.secretserver_local_user_management(
+        "list_sessions", skip=0, take=1, is_exporting=True
+    )
     assert res == {"ok": True}
     assert s.calls[0][2]["params"]["isExporting"]
 
-    res = tools.user_management("unknown")
+    res = secretserver_users.secretserver_local_user_management("unknown")
     assert res["error"] == "Unknown action: unknown"

--- a/tests/test_tools_errors.py
+++ b/tests/test_tools_errors.py
@@ -1,6 +1,6 @@
 import pytest
 
-from delinea_mcp import tools
+from delinea_mcp import secretserver_users, tools
 from delinea_mcp.session import SessionManager
 
 
@@ -22,16 +22,36 @@ def test_parse_json_data_bad():
 @pytest.mark.parametrize(
     "func,args,msg",
     [
-        (tools.user_management, ("get",), "user_id required for get"),
-        (tools.user_management, ("update",), "user_id and data required for update"),
-        (tools.user_management, ("delete",), "user_id required for delete"),
-        (tools.user_management, ("reset_2fa",), "user_id required for reset_2fa"),
         (
-            tools.user_management,
+            secretserver_users.secretserver_local_user_management,
+            ("get",),
+            "user_id required for get",
+        ),
+        (
+            secretserver_users.secretserver_local_user_management,
+            ("update",),
+            "user_id and data required for update",
+        ),
+        (
+            secretserver_users.secretserver_local_user_management,
+            ("delete",),
+            "user_id required for delete",
+        ),
+        (
+            secretserver_users.secretserver_local_user_management,
+            ("reset_2fa",),
+            "user_id required for reset_2fa",
+        ),
+        (
+            secretserver_users.secretserver_local_user_management,
             ("reset_password",),
             "user_id and data required for reset_password",
         ),
-        (tools.user_management, ("lock_out",), "user_id required for lock_out"),
+        (
+            secretserver_users.secretserver_local_user_management,
+            ("lock_out",),
+            "user_id required for lock_out",
+        ),
     ],
 )
 def test_user_management_missing(monkeypatch, func, args, msg):

--- a/tests/test_user_platform_tools.py
+++ b/tests/test_user_platform_tools.py
@@ -72,18 +72,21 @@ def test_platform_user_functions(monkeypatch):
 
 
 def test_platform_user_get(monkeypatch):
-    monkeypatch.setattr(user_platform_tools, "_headers", {"h": 1})
+    """v1.0.0+: get uses POST /UserMgmt/GetUserAttributes (modern Platform)."""
+    monkeypatch.setattr(user_platform_tools, "_headers", {"h": "1"})
     monkeypatch.setattr(user_platform_tools, "platform_hostname", "host")
     calls = []
 
-    def fake_get(url, **kwargs):
+    def fake_post(url, **kwargs):
         calls.append((url, kwargs))
         return DummyResponse()
 
-    monkeypatch.setattr(user_platform_tools.requests, "get", fake_get)
+    monkeypatch.setattr(user_platform_tools.requests, "post", fake_post)
     res = user_platform_tools.platform_user_management("get", user_id="x")
     assert res == {"ok": True}
-    assert "GetUser" in calls[0][0]
+    assert "GetUserAttributes" in calls[0][0]
+    # Body should be {"ID": "x"}
+    assert calls[0][1]["json"] == {"ID": "x"}
 
 
 def test_register(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "delinea-mcp"
-version = "0.1.0"
+version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## Summary

- **Breaking:** promotes the canonical `user_management` and `search_users` tools to the Delinea Platform identity API. SS-local equivalents are preserved as `secretserver_local_user_management` / `search_secretserver_local_users` for SS-only deployments.
- Adds three new flow tools: **`update_secret_fields`** (edit non-password fields with read-template→PUT-fields→verify), **`bulk_user_response`** (opinionated combinator over `/v1/bulk-user-operations/*` with `confirm=True` gate and preview-only default), and a Platform-side role/user-role parity pair (`platform_role_management`, `platform_user_role_management`).
- Live-verified against both a Secret Server cloud tenant and a Delinea Platform tenant (`dartlabs.secureplatform.io`); 32 integration tests pass.

## Why

Modern Delinea cloud deployments authenticate users through the Delinea Platform identity directory; Secret Server's `/v1/users/*` records are read-only mirrors there. v1.0.0 makes the canonical tool names track the authoritative user store. SS-only deployments retain access via the renamed tools.

The three new flows cover the most-asked agent workflows: editing a secret's non-sensitive fields without leaking passwords; bulk incident response on compromised users; and Platform-side role read (with discovery-driven write fallback).

## Breaking changes

| Old name | New name on Platform tenants | New name on SS-only tenants |
|---|---|---|
| `user_management` | `user_management` (talks to Platform) | `secretserver_local_user_management` |
| `search_users` | `search_users` (talks to Platform) | `search_secretserver_local_users` |

Clients with `enabled_tools: ["user_management"]` against SS-only deployments must either:
1. configure Platform (`PLATFORM_HOSTNAME`, `PLATFORM_SERVICE_ACCOUNT`, `PLATFORM_SERVICE_PASSWORD`, `PLATFORM_TENANT_ID`), or
2. switch the client to the new `secretserver_local_*` tool names.

`platform_user_management` is retained as a deprecated alias.

## New tools

### `update_secret_fields(secret_id, field_updates, comment=None, allow_password_fields=False)`

Reads `/v1/secrets/{id}/summary` for approval/comment gates, fetches the template to identify `isPassword=True` fields, then `PUT /v1/secrets/{id}/fields/{slug}` per entry. Refuses password-class slugs by default — those must go through `set_secret_field_environment_variable` so the value never enters model context. Audit comments route through `autoCheckout`/`autoCheckIn`/`autoComment` query params.

### `bulk_user_response(user_ids, scenario, comment, confirm=False)`

Scenarios: `compromise`, `offboard`, `unlock`, `reenable`, `force_logout`. Compromise runs `force-logout → lock → disable → reset-fido2 → reset-totp` in that order (force-logout first so active sessions are evicted before the disable propagates). Requires `confirm=True` and a non-empty `comment`; `confirm=False` returns a preview that makes no API calls.

### `platform_role_management(action, role_id=None, data=None, page_size=100, query="%")`

Reads via the `role_searchbyname` canned report on `/identity/api/Report/RunReport`. Writes (`create`/`update`/`delete`) attempt the documented Centrify-style endpoints (`SaasManage/StoreRole`, `Roles/UpdateRole`, `SaasManage/RemoveRole`) and fall back to a structured guidance error on HTTP 404 — tenants that expose those endpoints get the real result.

### `platform_user_role_management(action, role_id, user_principals=None)`

Same discovery-driven pattern for `add`/`remove`/`list`.

## Platform API discoveries (captured for future contributors)

While live-verifying on the dartlabs tenant, the documented Centrify-era API surface didn't match reality:

- The identity-API namespace is `/identity/api/...`, **not** `/identity/...` as the older user_platform_tools code assumed. `_platform_url()` now auto-prefixes correctly.
- `GetUser` (GET with query param) is gone; replaced by `GetUserAttributes` (POST with `{"ID": <uuid>}` body) which returns a richer record.
- Role mutation endpoints (`SaasManage/StoreRole`, `Roles/UpdateRole`, `SaasManage/RemoveRole`) return 404 via the `xpmheadless` OAuth scope on this tenant — but the code doesn't assume that's universal. The discovery-driven fallback means tenants with different scopes/deployments aren't locked out.

## Test plan

- [x] Run unit tests: `uv run pytest -q --ignore=tests/integration -k "not test_live"` — expect 173 passing
- [x] Set `DELINEA_USERNAME`/`DELINEA_PASSWORD`/`DELINEA_BASE_URL` + `LIVE_*` IDs for your SS tenant
- [x] Run SS integration tests: `uv run pytest tests/integration/test_tools_live.py -v` — expect 17 passing, 2 skipped (folder CRUD tenant-state + AI report no Azure key)
- [x] Set `PLATFORM_HOSTNAME`/`PLATFORM_SERVICE_ACCOUNT`/`PLATFORM_SERVICE_PASSWORD` for your Platform tenant
- [x] Run Platform integration tests: `uv run pytest tests/integration/test_platform_live.py -v` — expect 15 passing (will create + delete a `mcp-itest-*` user; sweeps clean on success or failure)
- [x] Verify no `mcp-itest-*` users remain after the run: `uv run python -c "from delinea_mcp import user_platform_tools as u; u.configure(...); print(u.search_users('mcp-itest'))"`
- [x] Confirm SS-only deployments still work: unset `PLATFORM_HOSTNAME` and call `secretserver_local_user_management('list_sessions')` — expect a real response, not an error
- [x] Confirm Platform-not-configured error path: with `PLATFORM_*` unset, call `user_management('get', user_id='x')` — expect a structured error pointing at `secretserver_local_user_management`
- [x] Confirm `update_secret_fields` refuses a password-class slug on a Web Password template secret
- [x] Confirm `bulk_user_response` `confirm=False` returns a preview without making API calls
- [x] Run `trunk fmt && trunk check` — expect no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)