### PR TITLE
fix(transports): route the SSE message channel through FastAPI so the OAuth guard applies

### DIFF
--- a/delinea_mcp/transports/sse.py
+++ b/delinea_mcp/transports/sse.py
@@ -32,4 +32,9 @@ def mount_sse_routes(
         return
 
     app.add_api_route("/mcp/sse", sse_endpoint, methods=["GET"])
-    app.mount("/messages", transport.handle_post_message)
+    # Register the POST channel through FastAPI instead of app.mount():
+    # Depends() does not apply to mounted ASGI sub-apps, so mounting
+    # transport.handle_post_message directly leaves every tool call
+    # (get_secret, update_secret_fields, ...) without the bearer-token
+    # check. post_message above exists for exactly this route.
+    app.add_api_route("/messages/", post_message, methods=["POST"])

--- a/tests/test_sse_transport.py
+++ b/tests/test_sse_transport.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.exceptions import HTTPException
+from httpx import ASGITransport, AsyncClient
+
+from delinea_mcp.transports.sse import mount_sse_routes
+
+
+async def _guard():
+    raise HTTPException(status_code=401, detail="no token")
+
+
+def _app_with_guard():
+    app = FastAPI()
+    mount_sse_routes(app, MagicMock(), _guard)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_sse_stream_requires_auth():
+    async with AsyncClient(
+        transport=ASGITransport(app=_app_with_guard()), base_url="http://t"
+    ) as client:
+        resp = await client.get("/mcp/sse")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_messages_post_channel_requires_auth():
+    # The POST channel carries every JSON-RPC tools/call. It must be behind
+    # the same dependency as the SSE stream; registering it via app.mount()
+    # would bypass FastAPI dependency injection entirely.
+    async with AsyncClient(
+        transport=ASGITransport(app=_app_with_guard()), base_url="http://t"
+    ) as client:
+        resp = await client.post("/messages/?session_id=abc", content=b"{}")
+    assert resp.status_code == 401


### PR DESCRIPTION
## Problem

In `mount_sse_routes` (delinea_mcp/transports/sse.py) the SSE stream is guarded:

```python
app.add_api_route("/mcp/sse", sse_endpoint, methods=["GET"])  # Depends(require_scopes(...))
```

but the message channel is attached as a mounted ASGI sub-app:

```python
app.mount("/messages", transport.handle_post_message)
```

**FastAPI's `Depends()` does not run for mounted sub-applications**, so the `require_scopes` bearer-token check passed in from `server.py` never executes on `POST /messages/?session_id=...` — the path that carries every JSON-RPC `tools/call`, i.e. every `get_secret`, `update_secret_fields`, `run_report`, and user/role mutation against Secret Server. The guarded `post_message` coroutine defined right above exists for exactly this route but is never registered — dead code showing the original intent.

The MCP SDK's own backstop (session-owner comparison in `handle_post_message`) degenerates to `None == None` here because the integration authenticates via `Depends` and never populates ASGI `scope["user"]` with an `AuthenticatedUser`, so `_session_owners` is never written. The only residual barrier was the unguessable uuid4 session id, which is an in-band URL-borne secret (proxy/access logs, and the debug middleware in server.py logs full request bodies). Separately, because tokens were only re-verified on the guarded GET, **token expiry or OAuth-client deletion had no effect on an established session**.

## Fix

One-line behavioral change: register the (previously dead) `post_message` through FastAPI so the dependency applies:

```python
app.add_api_route("/messages/", post_message, methods=["POST"])
```

## Verification

- Empirical before/after with the real transport module: mounted POST returned **200** with no `Authorization` header while the guarded GET returned 401; after the change, **both return 401**.
- New `tests/test_sse_transport.py` asserts both channels reject unauthenticated requests (2 passed).

Flagging as security-relevant rather than filing quietly per convention; happy to adjust wording or coordinate however you prefer. A reasonable follow-up (not in this PR) is populating ASGI `scope["user"]` with an `AuthenticatedUser` so the SDK's session-owner binding becomes effective as defense in depth.

Made with [Cursor](https://cursor.com)