### PR TITLE
fix(auth): actually require the PSK at POST /oauth/register

### DIFF
--- a/delinea_mcp/auth/routes.py
+++ b/delinea_mcp/auth/routes.py
@@ -42,7 +42,19 @@ def mount_oauth_routes(app: FastAPI, cfg: dict | None = None) -> None:
     async def register(request: Request):
         if registration_psk is None:
             raise HTTPException(status_code=400, detail="Registration disabled")
+        # The PSK is "required to register OAuth clients" per the README, but
+        # previously only its presence was tested - any anonymous caller could
+        # mint client_id/client_secret pairs. Require the shared secret, as
+        # the authorize handler already does. Accept it as a Bearer token
+        # (RFC 7591 initial-access-token style) or a JSON "secret" field.
+        import hmac
+
+        bearer = request.headers.get("authorization", "")
+        supplied = bearer[7:] if bearer.lower().startswith("bearer ") else None
         data = await request.json()
+        supplied = supplied or data.get("secret") or ""
+        if not hmac.compare_digest(supplied, registration_psk):
+            raise HTTPException(status_code=401, detail="invalid registration secret")
         logger.debug("register client %s", data.get("client_name"))
 
         client_name = data.get("client_name")

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -29,10 +29,30 @@ def test_registration_psk():
     r = client.post(
         "/oauth/register",
         json={"client_name": "t", "redirect_uris": ["http://localhost/callback"]},
+        headers={"Authorization": "Bearer sekret"},
     )
     assert r.status_code == 200
     data = r.json()
     assert "client_id" in data and "client_secret" in data
+
+
+def test_registration_requires_psk():
+    as_config.reset_state()
+    app = FastAPI()
+    mount_oauth_routes(app, {"registration_psk": "sekret", "oauth_db_path": ":memory:"})
+    client = TestClient(app)
+    payload = {"client_name": "t", "redirect_uris": ["http://localhost/callback"]}
+    # no secret at all
+    assert client.post("/oauth/register", json=payload).status_code == 401
+    # wrong secret
+    assert (
+        client.post("/oauth/register", json={**payload, "secret": "wrong"}).status_code
+        == 401
+    )
+    # secret in the JSON body also works
+    r = client.post("/oauth/register", json={**payload, "secret": "sekret"})
+    assert r.status_code == 200
+    assert "client_id" in r.json()
 
 
 def test_scope_enforcement(monkeypatch):


### PR DESCRIPTION
## Problem

`README.md` documents `registration_psk` as *"Pre-shared key required to register OAuth clients"*, but the handler at `delinea_mcp/auth/routes.py` only tests whether a PSK is **configured**:

```python
if registration_psk is None:
    raise HTTPException(status_code=400, detail="Registration disabled")
# ...never compares any request-supplied value
```

So while OAuth is enabled, **any anonymous caller** that can reach the server can `POST /oauth/register` with arbitrary `client_name` / `redirect_uris` and receive a working `client_id` and `client_secret`. The sibling `/oauth/authorize` submit handler does compare the PSK (`if secret != registration_psk`), which is what makes this a registration-boundary defect rather than a direct token path — but open registration enables attacker-controlled clients with attacker-chosen redirect URIs (a consent-phishing chain against an admin who holds the PSK) and unbounded client state growth. The existing test encoded the gap as expected behaviour: it registered with no secret and asserted 200.

## Fix

Require the shared secret with a constant-time comparison, accepted either as `Authorization: Bearer <psk>` (RFC 7591 initial-access-token style) or as a JSON `"secret"` field — matching how the authorize handler already treats it as a shared secret.

## Tests

- `test_registration_psk` updated to present the PSK (it previously asserted the vulnerable behaviour).
- New `test_registration_requires_psk`: 401 with no secret, 401 with a wrong secret, 200 with the body field.
- `pytest tests/test_oauth.py`: 8 passed.

Note: clients that register dynamically (e.g. MCP inspectors) will now need the PSK; that is exactly the documented contract.

Made with [Cursor](https://cursor.com)