### PR TITLE
fix(tools): honour enabled_tools for SS-local and Platform registration

### DIFF
--- a/delinea_mcp/secretserver_users.py
+++ b/delinea_mcp/secretserver_users.py
@@ -15,7 +15,7 @@ SS-only on-prem deployments and as a fallback during migration.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Iterable
 
 from .session import SessionManager
 
@@ -187,7 +187,16 @@ TOOLS = [
 ]
 
 
-def register(mcp: Any) -> None:
-    """Register the legacy SS-local user tools on a FastMCP server."""
-    for _name, func in TOOLS:
-        mcp.tool()(func)
+def register(mcp: Any, enabled: Iterable[str] | None = None) -> None:
+    """Register the legacy SS-local user tools on a FastMCP server.
+
+    Honours the same ``enabled_tools`` allowlist semantics as
+    :func:`delinea_mcp.tools.register`: an empty/missing set registers
+    every tool in this module; a non-empty set registers only named tools.
+    """
+    enabled_set = set(enabled or [])
+    if not enabled_set:
+        enabled_set = {name for name, _ in TOOLS}
+    for name, func in TOOLS:
+        if name in enabled_set:
+            mcp.tool()(func)

--- a/delinea_mcp/user_platform_tools.py
+++ b/delinea_mcp/user_platform_tools.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any
+from typing import Any, Iterable
 
 import requests
 
@@ -682,13 +682,20 @@ TOOLS = [
 ]
 
 
-def register(mcp: Any) -> None:
+def register(mcp: Any, enabled: Iterable[str] | None = None) -> None:
     """Register Platform tools on a FastMCP server.
 
-    Tools register unconditionally so the LLM always sees the canonical
-    ``user_management`` and ``search_users`` names.  When Platform is not
-    configured, calls return a helpful error directing the caller to
-    either configure Platform or use the legacy SS-local tools.
+    Honours the same ``enabled_tools`` allowlist semantics as
+    :func:`delinea_mcp.tools.register`: an empty/missing set registers
+    every tool in this module (including the canonical
+    ``user_management`` / ``search_users`` names); a non-empty set
+    registers only the named tools. When Platform is not configured,
+    registered tools still return a helpful error directing the caller
+    to configure Platform or use the legacy SS-local tools.
     """
+    enabled_set = set(enabled or [])
+    if not enabled_set:
+        enabled_set = {name for name, _ in TOOLS}
     for name, func in TOOLS:
-        mcp.tool()(func)
+        if name in enabled_set:
+            mcp.tool()(func)

--- a/server.py
+++ b/server.py
@@ -83,15 +83,16 @@ def _init_from_config(cfg: dict[str, Any]) -> None:
     enabled = set(cfg.get("enabled_tools", []))
     tools.register(mcp, enabled)
 
-    # Always register the legacy SS-local user tools so SS-only deployments
-    # have a fallback even when Platform is not configured.
-    secretserver_users.register(mcp)
+    # Register the legacy SS-local user tools under the same enabled_tools
+    # allowlist so SS-only deployments keep a fallback without bypassing a
+    # restricted ChatGPT/connector allowlist (empty = all tools).
+    secretserver_users.register(mcp, enabled)
 
-    # Configure Platform tools.  Always register them so the canonical
-    # user_management / search_users tool names are available to the
-    # client.  When Platform is not configured the tools return a clear
-    # error directing the caller to either configure Platform or use
-    # secretserver_local_*.
+    # Configure Platform tools. Register under the same enabled_tools
+    # allowlist so the canonical user_management / search_users names are
+    # available when selected (or when the allowlist is empty). When
+    # Platform is not configured the tools return a clear error directing
+    # the caller to either configure Platform or use secretserver_local_*.
     if cfg.get("platform_hostname"):
         user_platform_tools.configure(
             hostname=cfg.get("platform_hostname"),
@@ -105,7 +106,7 @@ def _init_from_config(cfg: dict[str, Any]) -> None:
             "Platform not configured; user_management/search_users will return "
             "a helpful error pointing at secretserver_local_* tools."
         )
-    user_platform_tools.register(mcp)
+    user_platform_tools.register(mcp, enabled)
 
 
 # Load default config on import using the config module's default resolution.

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,4 +1,4 @@
-from delinea_mcp import tools
+from delinea_mcp import secretserver_users, tools, user_platform_tools
 
 
 class DummyMCP:
@@ -33,6 +33,31 @@ def test_register_respects_enabled_list(monkeypatch):
     tools.register(dummy, {"get_secret", "run_report"})
     assert set(dummy.registered) == {"get_secret", "run_report"}
     assert "ai_generate_and_run_report" not in dummy.registered
+
+
+def test_secretserver_users_register_respects_enabled_list():
+    dummy = DummyMCP()
+    secretserver_users.register(
+        dummy, {"search", "fetch", "search_secrets", "get_secret"}
+    )
+    assert dummy.registered == []
+
+
+def test_user_platform_tools_register_respects_enabled_list():
+    dummy = DummyMCP()
+    user_platform_tools.register(
+        dummy, {"search", "fetch", "search_secrets", "get_secret"}
+    )
+    assert dummy.registered == []
+
+
+def test_secretserver_and_platform_register_all_when_enabled_empty():
+    ss = DummyMCP()
+    plat = DummyMCP()
+    secretserver_users.register(ss, set())
+    user_platform_tools.register(plat, set())
+    assert "secretserver_local_user_management" in ss.registered
+    assert "user_management" in plat.registered
 
 
 def test_load_enabled_tools(tmp_path):


### PR DESCRIPTION
## Problem

`docs/chatgpt-connector.md` (and sibling connector guides) tell operators to pin a narrow allowlist:

```json
"enabled_tools": ["search", "fetch", "search_secrets", "get_secret"]
```

`tools.register(mcp, enabled)` already respects that list, but `_init_from_config` always called:

- `secretserver_users.register(mcp)` (unconditional)
- `user_platform_tools.register(mcp)` (unconditional; docstring even said so)

So a ChatGPT/OAuth connector that was meant to expose only secret search/fetch still advertised and accepted:

- `user_management`, `search_users`
- `platform_role_management`, `platform_user_role_management`, `platform_user_management`
- `secretserver_local_user_management`, `search_secretserver_local_users`

including destructive actions (`delete`, `reset_password`, `lock_out`, Platform user CRUD).

## Fix

Pass the same `enabled` set into both `register` helpers. Empty/missing allowlist still means "all tools" (unchanged default).

## Test plan

- [x] `PYTHONPATH=. uv run pytest tests/test_register.py -q` (new cases for SS/Platform allowlist + empty=all)
- [ ] Confirm a ChatGPT-style config no longer lists admin tools in `tools/list`


Made with [Cursor](https://cursor.com)