### PR TITLE
fix(auth): chmod newly written JWT private key files to 0600

### DIFF
--- a/delinea_mcp/auth/as_config.py
+++ b/delinea_mcp/auth/as_config.py
@@ -56,6 +56,10 @@ def init_keys(path: str | Path | None) -> None:
     _PUBLIC_KEY = RSAKey.import_key(_PUBLIC_JWK)
     try:
         _KEY_FILE.write_text(json.dumps(_PRIVATE_KEY.as_dict(private=True)))
+        try:
+            os.chmod(_KEY_FILE, 0o600)
+        except Exception:
+            logger.exception("Failed to set permissions on %s", _KEY_FILE)
         logger.debug("Generated new OAuth keys at %s", _KEY_FILE)
     except Exception:
         logger.exception("Failed to write JWT keys to %s", _KEY_FILE)

--- a/tests/test_as_config_additional.py
+++ b/tests/test_as_config_additional.py
@@ -15,6 +15,13 @@ def test_init_keys_invalid_file(tmp_path, monkeypatch):
     assert as_config._PRIVATE_KEY is not None
 
 
+def test_init_keys_writes_private_key_mode_600(tmp_path):
+    target = tmp_path / "jwt.json"
+    as_config.init_keys(target)
+    assert target.exists()
+    assert (target.stat().st_mode & 0o777) == 0o600
+
+
 def test_init_keys_write_error(tmp_path, monkeypatch):
     target = tmp_path / "jwt.json"
 


### PR DESCRIPTION
## Problem

`init_db` already `chmod`s `oauth.db` to `0600`, but `init_keys` wrote the RSA private JWK via `Path.write_text` with the process umask (typically `0644`). On a shared host that leaves OAuth signing material world-readable next to a locked-down client DB.

## Fix

After writing a newly generated key file, set mode `0600` (same pattern as the OAuth DB). Load path unchanged.

## Test plan

- [x] `PYTHONPATH=. uv run pytest tests/test_as_config_additional.py -q` (asserts new key file mode is `0600`)


Made with [Cursor](https://cursor.com)