### PR TITLE
security: land open security fixes (#52-#55) + two transport follow-ups

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -7,5 +7,11 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   assign:
+    # Auto-assignment needs to write to PRs/issues; everything else is
+    # restricted rather than inheriting the default broad token.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     uses: delineaxpm/github-workflows/.github/workflows/assign.yml@main
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, develop]
   workflow_dispatch:
+# Restrict the default GITHUB_TOKEN: these jobs only read the repo.
+permissions:
+  contents: read
 env:
   UV_CACHE_DIR: /tmp/.uv-cache-delinea
   UV_HTTP_TIMEOUT: 120

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -39,7 +39,7 @@ lint:
     - isort@6.0.1
     - ruff@0.12.7
     - osv-scanner@2.0.3
-    - trivy@0.64.1
+    - trivy@0.73.0
     - trufflehog@3.90.4
     - renovate@41.71.1
     - git-diff-check

--- a/delinea_mcp/auth/as_config.py
+++ b/delinea_mcp/auth/as_config.py
@@ -56,6 +56,10 @@ def init_keys(path: str | Path | None) -> None:
     _PUBLIC_KEY = RSAKey.import_key(_PUBLIC_JWK)
     try:
         _KEY_FILE.write_text(json.dumps(_PRIVATE_KEY.as_dict(private=True)))
+        try:
+            os.chmod(_KEY_FILE, 0o600)
+        except Exception:
+            logger.exception("Failed to set permissions on %s", _KEY_FILE)
         logger.debug("Generated new OAuth keys at %s", _KEY_FILE)
     except Exception:
         logger.exception("Failed to write JWT keys to %s", _KEY_FILE)

--- a/delinea_mcp/auth/routes.py
+++ b/delinea_mcp/auth/routes.py
@@ -42,7 +42,19 @@ def mount_oauth_routes(app: FastAPI, cfg: dict | None = None) -> None:
     async def register(request: Request):
         if registration_psk is None:
             raise HTTPException(status_code=400, detail="Registration disabled")
+        # The PSK is "required to register OAuth clients" per the README, but
+        # previously only its presence was tested - any anonymous caller could
+        # mint client_id/client_secret pairs. Require the shared secret, as
+        # the authorize handler already does. Accept it as a Bearer token
+        # (RFC 7591 initial-access-token style) or a JSON "secret" field.
+        import hmac
+
+        bearer = request.headers.get("authorization", "")
+        supplied = bearer[7:] if bearer.lower().startswith("bearer ") else None
         data = await request.json()
+        supplied = supplied or data.get("secret") or ""
+        if not hmac.compare_digest(supplied, registration_psk):
+            raise HTTPException(status_code=401, detail="invalid registration secret")
         logger.debug("register client %s", data.get("client_name"))
 
         client_name = data.get("client_name")

--- a/delinea_mcp/auth/routes.py
+++ b/delinea_mcp/auth/routes.py
@@ -1,4 +1,5 @@
 import base64
+import hmac
 import html
 import logging
 from urllib.parse import urlencode
@@ -47,8 +48,6 @@ def mount_oauth_routes(app: FastAPI, cfg: dict | None = None) -> None:
         # mint client_id/client_secret pairs. Require the shared secret, as
         # the authorize handler already does. Accept it as a Bearer token
         # (RFC 7591 initial-access-token style) or a JSON "secret" field.
-        import hmac
-
         bearer = request.headers.get("authorization", "")
         supplied = bearer[7:] if bearer.lower().startswith("bearer ") else None
         data = await request.json()
@@ -112,7 +111,10 @@ def mount_oauth_routes(app: FastAPI, cfg: dict | None = None) -> None:
         state: str | None = Form(None),
     ):
         logger.debug("authorize_submit for %s", client_id)
-        if secret != registration_psk:
+        # Constant-time compare, matching the /oauth/register handler.
+        if registration_psk is None or not hmac.compare_digest(
+            secret, registration_psk
+        ):
             return Response(
                 content="Invalid secret", status_code=401, media_type="text/html"
             )

--- a/delinea_mcp/secretserver_users.py
+++ b/delinea_mcp/secretserver_users.py
@@ -15,7 +15,7 @@ SS-only on-prem deployments and as a fallback during migration.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Iterable
 
 from .session import SessionManager
 
@@ -187,7 +187,16 @@ TOOLS = [
 ]
 
 
-def register(mcp: Any) -> None:
-    """Register the legacy SS-local user tools on a FastMCP server."""
-    for _name, func in TOOLS:
-        mcp.tool()(func)
+def register(mcp: Any, enabled: Iterable[str] | None = None) -> None:
+    """Register the legacy SS-local user tools on a FastMCP server.
+
+    Honours the same ``enabled_tools`` allowlist semantics as
+    :func:`delinea_mcp.tools.register`: an empty/missing set registers
+    every tool in this module; a non-empty set registers only named tools.
+    """
+    enabled_set = set(enabled or [])
+    if not enabled_set:
+        enabled_set = {name for name, _ in TOOLS}
+    for name, func in TOOLS:
+        if name in enabled_set:
+            mcp.tool()(func)

--- a/delinea_mcp/transports/sse.py
+++ b/delinea_mcp/transports/sse.py
@@ -5,11 +5,26 @@ from fastapi.responses import Response
 from mcp.server.fastmcp import FastMCP
 from mcp.server.sse import SseServerTransport
 
+# Advertised verbatim to SSE clients (plus ?session_id=...) AND used as the
+# guarded POST route path. These must be the same string: MCP clients POST to
+# the advertised path without following redirects, so "/messages" vs
+# "/messages/" would break every tool call with a 307.
+MESSAGES_PATH = "/messages/"
+
+
+class _ResponseAlreadySent(Response):
+    """Returned by handlers whose response the MCP transport already sent
+    via the raw ASGI send channel; stops FastAPI from starting a second
+    response for the same request."""
+
+    async def __call__(self, scope, receive, send) -> None:
+        return
+
 
 def mount_sse_routes(
     app: FastAPI, mcp: FastMCP, dependency: Callable[..., Awaitable] | None = None
 ) -> None:
-    transport = SseServerTransport("/messages")
+    transport = SseServerTransport(MESSAGES_PATH)
 
     async def sse_endpoint(
         request: Request, auth=Depends(dependency) if dependency else None
@@ -20,8 +35,7 @@ def mount_sse_routes(
             await mcp._mcp_server.run(
                 streams[0], streams[1], mcp._mcp_server.create_initialization_options()
             )
-        return
-        # return Response()
+        return _ResponseAlreadySent()
 
     async def post_message(
         request: Request, auth=Depends(dependency) if dependency else None
@@ -29,7 +43,7 @@ def mount_sse_routes(
         await transport.handle_post_message(
             request.scope, request.receive, request._send
         )
-        return
+        return _ResponseAlreadySent()
 
     app.add_api_route("/mcp/sse", sse_endpoint, methods=["GET"])
     # Register the POST channel through FastAPI instead of app.mount():
@@ -37,4 +51,4 @@ def mount_sse_routes(
     # transport.handle_post_message directly leaves every tool call
     # (get_secret, update_secret_fields, ...) without the bearer-token
     # check. post_message above exists for exactly this route.
-    app.add_api_route("/messages/", post_message, methods=["POST"])
+    app.add_api_route(MESSAGES_PATH, post_message, methods=["POST"])

--- a/delinea_mcp/transports/sse.py
+++ b/delinea_mcp/transports/sse.py
@@ -32,4 +32,9 @@ def mount_sse_routes(
         return
 
     app.add_api_route("/mcp/sse", sse_endpoint, methods=["GET"])
-    app.mount("/messages", transport.handle_post_message)
+    # Register the POST channel through FastAPI instead of app.mount():
+    # Depends() does not apply to mounted ASGI sub-apps, so mounting
+    # transport.handle_post_message directly leaves every tool call
+    # (get_secret, update_secret_fields, ...) without the bearer-token
+    # check. post_message above exists for exactly this route.
+    app.add_api_route("/messages/", post_message, methods=["POST"])

--- a/delinea_mcp/user_platform_tools.py
+++ b/delinea_mcp/user_platform_tools.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any
+from typing import Any, Iterable
 
 import requests
 
@@ -682,13 +682,20 @@ TOOLS = [
 ]
 
 
-def register(mcp: Any) -> None:
+def register(mcp: Any, enabled: Iterable[str] | None = None) -> None:
     """Register Platform tools on a FastMCP server.
 
-    Tools register unconditionally so the LLM always sees the canonical
-    ``user_management`` and ``search_users`` names.  When Platform is not
-    configured, calls return a helpful error directing the caller to
-    either configure Platform or use the legacy SS-local tools.
+    Honours the same ``enabled_tools`` allowlist semantics as
+    :func:`delinea_mcp.tools.register`: an empty/missing set registers
+    every tool in this module (including the canonical
+    ``user_management`` / ``search_users`` names); a non-empty set
+    registers only the named tools. When Platform is not configured,
+    registered tools still return a helpful error directing the caller
+    to configure Platform or use the legacy SS-local tools.
     """
+    enabled_set = set(enabled or [])
+    if not enabled_set:
+        enabled_set = {name for name, _ in TOOLS}
     for name, func in TOOLS:
-        mcp.tool()(func)
+        if name in enabled_set:
+            mcp.tool()(func)

--- a/server.py
+++ b/server.py
@@ -83,15 +83,16 @@ def _init_from_config(cfg: dict[str, Any]) -> None:
     enabled = set(cfg.get("enabled_tools", []))
     tools.register(mcp, enabled)
 
-    # Always register the legacy SS-local user tools so SS-only deployments
-    # have a fallback even when Platform is not configured.
-    secretserver_users.register(mcp)
+    # Register the legacy SS-local user tools under the same enabled_tools
+    # allowlist so SS-only deployments keep a fallback without bypassing a
+    # restricted ChatGPT/connector allowlist (empty = all tools).
+    secretserver_users.register(mcp, enabled)
 
-    # Configure Platform tools.  Always register them so the canonical
-    # user_management / search_users tool names are available to the
-    # client.  When Platform is not configured the tools return a clear
-    # error directing the caller to either configure Platform or use
-    # secretserver_local_*.
+    # Configure Platform tools. Register under the same enabled_tools
+    # allowlist so the canonical user_management / search_users names are
+    # available when selected (or when the allowlist is empty). When
+    # Platform is not configured the tools return a clear error directing
+    # the caller to either configure Platform or use secretserver_local_*.
     if cfg.get("platform_hostname"):
         user_platform_tools.configure(
             hostname=cfg.get("platform_hostname"),
@@ -105,7 +106,7 @@ def _init_from_config(cfg: dict[str, Any]) -> None:
             "Platform not configured; user_management/search_users will return "
             "a helpful error pointing at secretserver_local_* tools."
         )
-    user_platform_tools.register(mcp)
+    user_platform_tools.register(mcp, enabled)
 
 
 # Load default config on import using the config module's default resolution.

--- a/tests/test_as_config_additional.py
+++ b/tests/test_as_config_additional.py
@@ -15,6 +15,13 @@ def test_init_keys_invalid_file(tmp_path, monkeypatch):
     assert as_config._PRIVATE_KEY is not None
 
 
+def test_init_keys_writes_private_key_mode_600(tmp_path):
+    target = tmp_path / "jwt.json"
+    as_config.init_keys(target)
+    assert target.exists()
+    assert (target.stat().st_mode & 0o777) == 0o600
+
+
 def test_init_keys_write_error(tmp_path, monkeypatch):
     target = tmp_path / "jwt.json"
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -29,10 +29,30 @@ def test_registration_psk():
     r = client.post(
         "/oauth/register",
         json={"client_name": "t", "redirect_uris": ["http://localhost/callback"]},
+        headers={"Authorization": "Bearer sekret"},
     )
     assert r.status_code == 200
     data = r.json()
     assert "client_id" in data and "client_secret" in data
+
+
+def test_registration_requires_psk():
+    as_config.reset_state()
+    app = FastAPI()
+    mount_oauth_routes(app, {"registration_psk": "sekret", "oauth_db_path": ":memory:"})
+    client = TestClient(app)
+    payload = {"client_name": "t", "redirect_uris": ["http://localhost/callback"]}
+    # no secret at all
+    assert client.post("/oauth/register", json=payload).status_code == 401
+    # wrong secret
+    assert (
+        client.post("/oauth/register", json={**payload, "secret": "wrong"}).status_code
+        == 401
+    )
+    # secret in the JSON body also works
+    r = client.post("/oauth/register", json={**payload, "secret": "sekret"})
+    assert r.status_code == 200
+    assert "client_id" in r.json()
 
 
 def test_scope_enforcement(monkeypatch):

--- a/tests/test_oauth_flow.py
+++ b/tests/test_oauth_flow.py
@@ -48,7 +48,11 @@ async def test_full_oauth_flow(monkeypatch):
     async with AsyncClient(transport=transport, base_url="http://testserver") as client:
         r = await client.post(
             "/oauth/register",
-            json={"client_name": "c", "redirect_uris": ["http://testserver/cb"]},
+            json={
+                "client_name": "c",
+                "redirect_uris": ["http://testserver/cb"],
+                "secret": "psk",
+            },
         )
         data = r.json()
         cid = data["client_id"]
@@ -106,7 +110,11 @@ async def test_token_invalid_secret(monkeypatch):
     async with AsyncClient(transport=transport, base_url="http://testserver") as client:
         r = await client.post(
             "/oauth/register",
-            json={"client_name": "c", "redirect_uris": ["http://localhost/callback"]},
+            json={
+                "client_name": "c",
+                "redirect_uris": ["http://localhost/callback"],
+                "secret": "psk",
+            },
         )
         data = r.json()
         cid = data["client_id"]

--- a/tests/test_oauth_routes_additional.py
+++ b/tests/test_oauth_routes_additional.py
@@ -52,7 +52,11 @@ def test_token_unsupported_grant(monkeypatch):
     # register and create code
     data = client.post(
         "/oauth/register",
-        json={"client_name": "c", "redirect_uris": ["http://localhost/callback"]},
+        json={
+            "client_name": "c",
+            "redirect_uris": ["http://localhost/callback"],
+            "secret": "psk",
+        },
     ).json()
     code = as_config.create_code(data["client_id"], ["mcp.read"])
     r = client.post(

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,4 +1,4 @@
-from delinea_mcp import tools
+from delinea_mcp import secretserver_users, tools, user_platform_tools
 
 
 class DummyMCP:
@@ -33,6 +33,31 @@ def test_register_respects_enabled_list(monkeypatch):
     tools.register(dummy, {"get_secret", "run_report"})
     assert set(dummy.registered) == {"get_secret", "run_report"}
     assert "ai_generate_and_run_report" not in dummy.registered
+
+
+def test_secretserver_users_register_respects_enabled_list():
+    dummy = DummyMCP()
+    secretserver_users.register(
+        dummy, {"search", "fetch", "search_secrets", "get_secret"}
+    )
+    assert dummy.registered == []
+
+
+def test_user_platform_tools_register_respects_enabled_list():
+    dummy = DummyMCP()
+    user_platform_tools.register(
+        dummy, {"search", "fetch", "search_secrets", "get_secret"}
+    )
+    assert dummy.registered == []
+
+
+def test_secretserver_and_platform_register_all_when_enabled_empty():
+    ss = DummyMCP()
+    plat = DummyMCP()
+    secretserver_users.register(ss, set())
+    user_platform_tools.register(plat, set())
+    assert "secretserver_local_user_management" in ss.registered
+    assert "user_management" in plat.registered
 
 
 def test_load_enabled_tools(tmp_path):

--- a/tests/test_server_platform.py
+++ b/tests/test_server_platform.py
@@ -27,7 +27,7 @@ def test_server_registers_platform_tools(monkeypatch, tmp_path):
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
     called = {}
 
-    def fake_register(mcp):
+    def fake_register(mcp, enabled=None):
         called["reg"] = True
 
     def fake_configure(**kw):

--- a/tests/test_sse_routes.py
+++ b/tests/test_sse_routes.py
@@ -19,4 +19,7 @@ def test_post_routes_mounted():
     routes = {r.path: r for r in app.router.routes}
     assert type(routes["/mcp/sse"]).__name__ == "APIRoute"
     assert "GET" in getattr(routes["/mcp/sse"], "methods", set())
-    assert type(routes["/messages"]).__name__ == "Mount"
+    # The POST channel must be a real route (not a Mount) so FastAPI
+    # dependencies apply to it.
+    assert type(routes["/messages/"]).__name__ == "APIRoute"
+    assert "POST" in getattr(routes["/messages/"], "methods", set())

--- a/tests/test_sse_routes_additional.py
+++ b/tests/test_sse_routes_additional.py
@@ -21,8 +21,8 @@ def test_routes_mounted_and_post_accessible():
     app = FastAPI()
     mount_sse_routes(app, DummyMCP())
     routes = {r.path: getattr(r, "methods", set()) for r in app.router.routes}
-    assert "/messages" in routes
+    assert "POST" in routes.get("/messages/", set())
     assert "GET" in routes.get("/mcp/sse", set())
     client = TestClient(app)
-    r = client.post("/messages")
+    r = client.post("/messages/")
     assert r.status_code == 400

--- a/tests/test_sse_transport.py
+++ b/tests/test_sse_transport.py
@@ -37,3 +37,26 @@ async def test_messages_post_channel_requires_auth():
     ) as client:
         resp = await client.post("/messages/?session_id=abc", content=b"{}")
     assert resp.status_code == 401
+
+
+def test_advertised_endpoint_matches_registered_post_route(monkeypatch):
+    # The transport advertises its endpoint string verbatim to clients via
+    # the SSE "endpoint" event. MCP clients POST there without following
+    # redirects, so the advertised path must exactly match a registered
+    # POST route (e.g. "/messages" vs "/messages/" would 307).
+    import delinea_mcp.transports.sse as sse_mod
+
+    captured = {}
+    real_transport = sse_mod.SseServerTransport
+
+    def capturing(endpoint, *args, **kwargs):
+        captured["endpoint"] = endpoint
+        return real_transport(endpoint, *args, **kwargs)
+
+    monkeypatch.setattr(sse_mod, "SseServerTransport", capturing)
+    app = FastAPI()
+    mount_sse_routes(app, MagicMock())
+    post_paths = {
+        r.path for r in app.router.routes if "POST" in getattr(r, "methods", set())
+    }
+    assert captured["endpoint"] in post_paths

--- a/tests/test_sse_transport.py
+++ b/tests/test_sse_transport.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.exceptions import HTTPException
+from httpx import ASGITransport, AsyncClient
+
+from delinea_mcp.transports.sse import mount_sse_routes
+
+
+async def _guard():
+    raise HTTPException(status_code=401, detail="no token")
+
+
+def _app_with_guard():
+    app = FastAPI()
+    mount_sse_routes(app, MagicMock(), _guard)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_sse_stream_requires_auth():
+    async with AsyncClient(
+        transport=ASGITransport(app=_app_with_guard()), base_url="http://t"
+    ) as client:
+        resp = await client.get("/mcp/sse")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_messages_post_channel_requires_auth():
+    # The POST channel carries every JSON-RPC tools/call. It must be behind
+    # the same dependency as the SSE stream; registering it via app.mount()
+    # would bypass FastAPI dependency injection entirely.
+    async with AsyncClient(
+        transport=ASGITransport(app=_app_with_guard()), base_url="http://t"
+    ) as client:
+        resp = await client.post("/messages/?session_id=abc", content=b"{}")
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Lands the four open security PRs as cherry-picks (authorship preserved) plus two follow-up fixes found while verifying them:

- **#52** — route the SSE `/messages` channel through FastAPI so the OAuth guard applies (previously every `tools/call` over SSE+OAuth was unauthenticated)
- **#53** — actually require the registration PSK at `POST /oauth/register` (constant-time compare, Bearer or JSON `secret`)
- **#54** — honour the `enabled_tools` allowlist for SS-local and Platform registrars
- **#55** — chmod newly written JWT private key files to 0600

Follow-ups on top of #52:

- The transport advertised `/messages` to SSE clients while the guarded route is `/messages/`; MCP clients don't follow the 307 redirect, so every tool call would have broken. A single `MESSAGES_PATH` constant now feeds both, with a regression test capturing the constructor argument.
- The transport sends its own response through the raw ASGI channel, and FastAPI then started a second response for the endpoint's `None` return ('Received multiple http.response.start'). Handlers now return a no-op Response marker — this also fixes the latent double-send on SSE stream teardown.
- Existing suites updated where they encoded the pre-fix behaviour (OAuth flow tests registering without a PSK, SSE tests asserting the dependency-bypassing Mount, a register stub without the `enabled` arg).

Closes #52. Closes #53. Closes #54. Closes #55.

## Test plan

- [x] `PYTHONPATH=. uv run pytest --ignore=tests/integration -k 'not test_live'` — 212 passed
- [x] Live Secret Server suite (17 passed) and live Platform suite (15 passed) on the follow-up branch stacked on this one

🤖 Generated with [Claude Code](https://claude.com/claude-code)